### PR TITLE
feat: 추출 이력 기반 채팅 키워드 검색 기능 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -777,9 +777,11 @@ with tab_search:
                 "검색 키워드 (대화 내용에서 정확히 포함된 파일을 찾습니다)",
                 key="search_keyword_input",
                 placeholder="예: 블랙, 환불, 입금",
+                on_change=lambda: st.session_state.update({"search_trigger": True}),
             )
 
-            if st.button("🔍 검색", type="primary", key="search_run_btn"):
+            search_triggered = st.session_state.pop("search_trigger", False)
+            if st.button("🔍 검색", type="primary", key="search_run_btn") or search_triggered:
                 if not keyword.strip():
                     st.warning("검색 키워드를 입력해 주세요.")
                 else:
@@ -793,10 +795,13 @@ with tab_search:
                             "(채팅 검색 기능 적용 이전에 추출되었거나 DB 미연결 상태로 추출된 작업입니다.)"
                         )
                     else:
+                        live_date = None
+                        if selected_job.get("live_start_time"):
+                            live_date = selected_job["live_start_time"][:10]
                         results = []
                         for f in raw_files:
                             matches = search_keyword_in_raw_csv(
-                                f.get("content", ""), keyword
+                                f.get("content", ""), keyword, live_date=live_date
                             )
                             if matches:
                                 results.append(
@@ -805,8 +810,6 @@ with tab_search:
                                         "chat_name": f.get("chat_name") or "-",
                                         "filename": f.get("filename"),
                                         "content": f.get("content", ""),
-                                        "count": len(matches),
-                                        "preview": matches[0]["message"],
                                     }
                                 )
                         st.session_state["search_results"] = {
@@ -827,20 +830,40 @@ with tab_search:
                 if not items:
                     st.info("매칭되는 파일이 없습니다.")
                 else:
-                    header = st.columns([2, 4, 1, 1])
+                    page_size = 20
+                    total_pages = max(1, (len(items) + page_size - 1) // page_size)
+                    if "search_page" not in st.session_state:
+                        st.session_state["search_page"] = 0
+                    # 새 검색 시 페이지 초기화
+                    if st.session_state.get("search_results_keyword") != sr["keyword"]:
+                        st.session_state["search_page"] = 0
+                        st.session_state["search_results_keyword"] = sr["keyword"]
+                    page = st.session_state["search_page"]
+
+                    start = page * page_size
+                    end = start + page_size
+                    page_items = items[start:end]
+
+                    header = st.columns([6, 1])
                     header[0].markdown("**채팅명**")
-                    header[1].markdown("**미리보기**")
-                    header[2].markdown("**매칭**")
-                    header[3].markdown("**다운로드**")
-                    for r in items:
-                        c1, c2, c3, c4 = st.columns([2, 4, 1, 1])
-                        c1.write(r["chat_name"])
-                        c2.caption(r["preview"][:80])
-                        c3.write(f"{r['count']}건")
-                        c4.download_button(
+                    header[1].markdown("**다운로드**")
+                    for r in page_items:
+                        c1, c2 = st.columns([6, 1])
+                        c1.write(r["filename"])
+                        c2.download_button(
                             label="📥",
                             data=r["content"].encode("utf-8-sig"),
                             file_name=r["filename"],
                             mime="text/csv",
                             key=f"search_dl_{r['id']}",
                         )
+
+                    if total_pages > 1:
+                        st.caption(f"{page + 1} / {total_pages} 페이지")
+                        nav_cols = st.columns([1, 1, 8])
+                        if nav_cols[0].button("◀ 이전", key="search_prev", disabled=(page == 0)):
+                            st.session_state["search_page"] -= 1
+                            st.rerun()
+                        if nav_cols[1].button("다음 ▶", key="search_next", disabled=(page >= total_pages - 1)):
+                            st.session_state["search_page"] += 1
+                            st.rerun()

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from services import (
     normalize_zip_code,
     batch_lookup_zip_codes,
     extract_chat_name,
+    search_keyword_in_raw_csv,
 )
 from database import (
     get_connection,
@@ -29,6 +30,8 @@ from database import (
     get_jobs_by_user,
     get_orders_by_job,
     get_catalog_by_job,
+    save_raw_chat_files,
+    get_raw_files_by_job,
 )
 
 # --- UI 구성 ---
@@ -135,8 +138,14 @@ with st.sidebar:
             st.info(f"이번 달 사용량: {monthly_used} / {monthly_limit}")
 
 # --- 탭 구성 ---
-tab_order, tab_catalog, tab_zipcode, tab_history = st.tabs(
-    ["📦 주문서 추출", "📋 카탈로그 생성", "📮 우편번호 추출", "🗂️ 나의 추출 이력"]
+tab_order, tab_catalog, tab_zipcode, tab_history, tab_search = st.tabs(
+    [
+        "📦 주문서 추출",
+        "📋 카탈로그 생성",
+        "📮 우편번호 추출",
+        "🗂️ 나의 추출 이력",
+        "🔎 채팅 검색",
+    ]
 )
 
 # ===== 탭 1: 주문서 추출 (기존 기능) =====
@@ -245,6 +254,7 @@ with tab_order:
                 st.write("📋 카탈로그를 파싱 중")
                 catalog_data = parse_catalog_json(catalog_file)
                 all_extracted_orders = []
+                raw_files_buffer = []
 
                 job_id = None
                 if db_conn:
@@ -271,6 +281,21 @@ with tab_order:
                         exclude_messages=config["csv"]["exclude_messages"],
                         time_after=time_after,
                         time_before=time_before,
+                    )
+
+                    # 원본 CSV를 키워드 검색용으로 보관 (탭 "채팅 검색")
+                    raw_files_buffer.append(
+                        {
+                            "filename": file_display,
+                            "chat_name": extract_chat_name(
+                                file_display,
+                                filename_prefix=config["csv"]["filename_prefix"],
+                            ),
+                            "content": chat_file.getvalue().decode(
+                                "utf-8-sig", errors="replace"
+                            ),
+                            "message_count": len(chat_data),
+                        }
                     )
 
                     try:
@@ -330,6 +355,14 @@ with tab_order:
 
                     progress_bar.progress((i + 1) / total_files)
                     progress_text.write(f"💬 채팅 내역 분석 중 ({i + 1}/{total_files})")
+
+                if db_conn and job_id and raw_files_buffer:
+                    save_raw_chat_files(
+                        conn=db_conn,
+                        job_id=job_id,
+                        user_id=st.session_state["logged_in_user"],
+                        files=raw_files_buffer,
+                    )
 
                 if juso_api_key:
                     st.write("📮 우편번호 조회 중")
@@ -706,4 +739,108 @@ with tab_history:
                             disabled=True,
                             key="hist_catalog_btn_disabled",
                             use_container_width=True,
+                        )
+
+# ===== 탭 5: 채팅 검색 =====
+with tab_search:
+    if not db_conn:
+        st.warning("DB 연결이 설정되지 않아 검색할 수 없습니다.")
+    else:
+        jobs = get_jobs_by_user(
+            conn=db_conn,
+            user_id=st.session_state["logged_in_user"],
+        )
+
+        if not jobs:
+            st.info("저장된 추출 이력이 없습니다. 먼저 주문서 추출을 실행해 주세요.")
+        else:
+            job_labels = []
+            for j in jobs:
+                live_str = (
+                    j["live_start_time"][:16].replace("T", " ")
+                    if j.get("live_start_time")
+                    else "-"
+                )
+                job_labels.append(
+                    f"{j['title']}  |  라이브: {live_str}  |  {j['total_orders']}건"
+                )
+
+            search_idx = st.radio(
+                "검색할 추출 작업을 선택하세요 (최근 5건)",
+                options=range(len(jobs)),
+                format_func=lambda i: job_labels[i],
+                key="search_job_radio",
+            )
+            selected_job = jobs[search_idx]
+
+            keyword = st.text_input(
+                "검색 키워드 (대화 내용에서 정확히 포함된 파일을 찾습니다)",
+                key="search_keyword_input",
+                placeholder="예: 블랙, 환불, 입금",
+            )
+
+            if st.button("🔍 검색", type="primary", key="search_run_btn"):
+                if not keyword.strip():
+                    st.warning("검색 키워드를 입력해 주세요.")
+                else:
+                    raw_files = get_raw_files_by_job(
+                        conn=db_conn, job_id=selected_job["id"]
+                    )
+                    if not raw_files:
+                        st.session_state["search_results"] = None
+                        st.info(
+                            "이 작업은 원본 대화가 저장되지 않았습니다. "
+                            "(채팅 검색 기능 적용 이전에 추출되었거나 DB 미연결 상태로 추출된 작업입니다.)"
+                        )
+                    else:
+                        results = []
+                        for f in raw_files:
+                            matches = search_keyword_in_raw_csv(
+                                f.get("content", ""), keyword
+                            )
+                            if matches:
+                                results.append(
+                                    {
+                                        "id": f["id"],
+                                        "chat_name": f.get("chat_name") or "-",
+                                        "filename": f.get("filename"),
+                                        "content": f.get("content", ""),
+                                        "count": len(matches),
+                                        "preview": matches[0]["message"],
+                                    }
+                                )
+                        st.session_state["search_results"] = {
+                            "keyword": keyword,
+                            "job_id": selected_job["id"],
+                            "items": results,
+                            "total": len(raw_files),
+                        }
+
+            # download_button 클릭으로 rerun돼도 결과가 유지되도록 session_state 사용
+            sr = st.session_state.get("search_results")
+            if sr and sr.get("job_id") == selected_job["id"]:
+                items = sr["items"]
+                st.caption(
+                    f"'{sr['keyword']}' 검색 결과: {len(items)}개 파일 매칭 "
+                    f"(전체 {sr['total']}개 중)"
+                )
+                if not items:
+                    st.info("매칭되는 파일이 없습니다.")
+                else:
+                    header = st.columns([2, 4, 1, 1])
+                    header[0].markdown("**채팅명**")
+                    header[1].markdown("**미리보기**")
+                    header[2].markdown("**매칭**")
+                    header[3].markdown("**다운로드**")
+                    for r in items:
+                        c1, c2, c3, c4 = st.columns([2, 4, 1, 1])
+                        c1.write(r["chat_name"])
+                        c2.caption(r["preview"][:80])
+                        c3.write(f"{r['count']}건")
+                        c4.download_button(
+                            label="📥",
+                            data=r["content"].encode("utf-8-sig"),
+                            file_name=r["filename"],
+                            mime="text/csv",
+                            key=f"search_dl_{r['id']}",
                         )

--- a/database.py
+++ b/database.py
@@ -205,3 +205,48 @@ def get_orders_by_job(
         .execute()
     )
     return result.data
+
+
+def save_raw_chat_files(
+    conn: Client,
+    job_id: str,
+    user_id: str,
+    files: list[dict],
+) -> None:
+    """raw_chat_files 테이블에 원본 CSV row들을 일괄 삽입합니다.
+
+    files의 각 dict는 다음 키를 포함해야 합니다:
+    filename, chat_name, content, message_count
+    """
+    if not files:
+        return
+    rows = [
+        {
+            "job_id": job_id,
+            "user_id": user_id,
+            "filename": f.get("filename"),
+            "chat_name": f.get("chat_name"),
+            "content": f.get("content"),
+            "message_count": f.get("message_count"),
+            "created_at": datetime.now().isoformat(),
+        }
+        for f in files
+    ]
+    conn.table("raw_chat_files").insert(rows).execute()
+
+
+def get_raw_files_by_job(
+    conn: Client,
+    job_id: str,
+) -> list[dict]:
+    """job_id에 해당하는 원본 CSV 파일 목록을 반환합니다.
+    반환 키: id, filename, chat_name, content, message_count
+    """
+    result = (
+        conn.table("raw_chat_files")
+        .select("id, filename, chat_name, content, message_count")
+        .eq("job_id", job_id)
+        .order("filename")
+        .execute()
+    )
+    return result.data

--- a/services.py
+++ b/services.py
@@ -350,12 +350,15 @@ def parse_csv(
     return messages, timestamp
 
 
-def search_keyword_in_raw_csv(content: str, keyword: str) -> list[dict]:
+def search_keyword_in_raw_csv(
+    content: str, keyword: str, live_date: str | None = None
+) -> list[dict]:
     """원본 CSV 텍스트의 MESSAGE 컬럼에서 keyword를 단순 부분 매칭으로 검색합니다.
 
     반환: 매칭된 메시지 [{"user", "message", "date"}], 매칭이 없으면 빈 리스트.
     - MESSAGE 컬럼만 대상으로 하며, exclude_messages/공백정규화는 적용하지 않습니다(raw 기준).
     - 매칭 판정은 `keyword in message` (대소문자/공백 정규화·퍼지·단어경계 없음).
+    - live_date("YYYY-MM-DD")가 주어지면 해당 날짜의 메시지만 검색합니다.
     - 빈 키워드이거나 MESSAGE 컬럼이 없으면 빈 리스트를 반환합니다.
     """
     if not keyword:
@@ -364,6 +367,10 @@ def search_keyword_in_raw_csv(content: str, keyword: str) -> list[dict]:
     df = pd.read_csv(io.StringIO(content), encoding_errors="replace")
     if "MESSAGE" not in df.columns:
         return []
+
+    if live_date and "DATE" in df.columns:
+        df["DATE"] = pd.to_datetime(df["DATE"], errors="coerce")
+        df = df[df["DATE"].dt.strftime("%Y-%m-%d") == live_date]
 
     matches = []
     for _, row in df.iterrows():

--- a/services.py
+++ b/services.py
@@ -348,3 +348,32 @@ def parse_csv(
         messages.append({"user": user, "message": message})
 
     return messages, timestamp
+
+
+def search_keyword_in_raw_csv(content: str, keyword: str) -> list[dict]:
+    """원본 CSV 텍스트의 MESSAGE 컬럼에서 keyword를 단순 부분 매칭으로 검색합니다.
+
+    반환: 매칭된 메시지 [{"user", "message", "date"}], 매칭이 없으면 빈 리스트.
+    - MESSAGE 컬럼만 대상으로 하며, exclude_messages/공백정규화는 적용하지 않습니다(raw 기준).
+    - 매칭 판정은 `keyword in message` (대소문자/공백 정규화·퍼지·단어경계 없음).
+    - 빈 키워드이거나 MESSAGE 컬럼이 없으면 빈 리스트를 반환합니다.
+    """
+    if not keyword:
+        return []
+
+    df = pd.read_csv(io.StringIO(content), encoding_errors="replace")
+    if "MESSAGE" not in df.columns:
+        return []
+
+    matches = []
+    for _, row in df.iterrows():
+        message = str(row.get("MESSAGE", ""))
+        if keyword in message:
+            matches.append(
+                {
+                    "user": row.get("USER", ""),
+                    "message": message,
+                    "date": row.get("DATE", ""),
+                }
+            )
+    return matches


### PR DESCRIPTION
## Summary

- 주문서 추출 시 원본 CSV를 `raw_chat_files` 테이블에 `job_id`와 함께 저장
- **"🔎 채팅 검색"** 탭 신설: 과거 추출 작업을 고르면 그때의 원본 대화에서 키워드를 검색해 매칭 파일을 개별 다운로드
- MESSAGE 컬럼 단순 부분 매칭 (`keyword in message`), 추출 이력 탭과 동일한 job 셀렉터 패턴 재사용

## 변경 파일

| 파일 | 변경 내용 |
| --- | --- |
| `services.py` | `search_keyword_in_raw_csv(content, keyword)` 추가 |
| `database.py` | `save_raw_chat_files`, `get_raw_files_by_job` 추가 |
| `app.py` | 추출 루프에 raw 저장 배선 + "🔎 채팅 검색" 탭 신설 |

## Supabase 사전 작업 (배포 전 필수)

Supabase SQL Editor에서 아래 DDL 실행:

```sql
create table raw_chat_files (
  id            uuid primary key default gen_random_uuid(),
  job_id        uuid not null references extraction_jobs(id) on delete cascade,
  user_id       text not null,
  filename      text not null,
  chat_name     text,
  content       text not null,
  message_count int,
  created_at    timestamptz not null default now()
);
create index idx_raw_files_job on raw_chat_files (job_id);
```

> RLS는 기존 테이블(`extraction_jobs` 등) 운영 방식과 동일하게 적용

## Test plan

- [ ] Supabase에 `raw_chat_files` 테이블 DDL 실행
- [ ] 주문서 추출 1회 실행 → `raw_chat_files`에 원본 행 저장 확인
- [ ] "🔎 채팅 검색" 탭 → job 선택 → 키워드 검색 → 매칭 결과 노출 확인
- [ ] 매칭 파일 개별 다운로드 → 원본 CSV와 내용 일치 확인
- [ ] 원본 미저장 과거 job 선택 시 안내 메시지 노출 확인
- [ ] 빈 키워드 검색 시 경고 메시지 노출 확인

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)