### PR TITLE
fix: pyarrow 네이티브 의존성 버전 스큐로 인한 카탈로그 업로드 segfault 수정

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ if not st.session_state["logged_in_user"]:
             email = st.text_input("이메일")
             password = st.text_input("비밀번호", type="password")
             submit_button = st.form_submit_button(
-                "LogIn", use_container_width=True, type="primary"
+                "LogIn", width="stretch", type="primary"
             )
 
             if submit_button:
@@ -222,7 +222,7 @@ with tab_order:
     time_after = datetime.datetime.combine(start_date, start_time)
     time_before = datetime.datetime.combine(end_date, end_time)
 
-    if st.button("🚀 주문서 추출 실행", type="primary", use_container_width=True):
+    if st.button("🚀 주문서 추출 실행", type="primary", width="stretch"):
         if not st.session_state.get("api_key"):
             st.warning("API Key가 할당되지 않았습니다. 관리자에게 문의하세요.")
         elif not catalog_file:
@@ -400,7 +400,7 @@ with tab_order:
                 df = df.rename(columns=rename)
                 df = df.reindex(columns=list(col_map.keys()), fill_value="")
 
-                st.dataframe(df, use_container_width=True)
+                st.dataframe(df, width="stretch")
 
                 output = io.BytesIO()
                 with pd.ExcelWriter(
@@ -481,7 +481,7 @@ with tab_catalog:
         preview_df = pd.DataFrame(preview_rows)
         preview_df.index = preview_df.index + 1
         preview_df.index.name = "#"
-        st.dataframe(preview_df, use_container_width=True)
+        st.dataframe(preview_df, width="stretch")
 
         st.markdown(
             '<span class="step-badge">3</span> **카탈로그 다운로드**',
@@ -497,7 +497,7 @@ with tab_catalog:
             file_name=f"catalog_{timestamp}.json",
             mime="application/json",
             type="primary",
-            use_container_width=True,
+            width="stretch",
         )
 
 # ===== 탭 3: 우편번호 추출 =====
@@ -528,13 +528,13 @@ with tab_zipcode:
                 st.info(
                     "파일에 이미 '우편번호' 컬럼이 있습니다. 조회 결과로 덮어씁니다."
                 )
-            st.dataframe(zip_df.head(10), use_container_width=True)
+            st.dataframe(zip_df.head(10), width="stretch")
             st.caption(f"총 {len(zip_df)}건")
 
             if st.button(
                 "📮 우편번호 조회 실행",
                 type="primary",
-                use_container_width=True,
+                width="stretch",
                 key="zip_lookup_btn",
             ):
                 if not st.session_state.get("api_key"):
@@ -593,7 +593,7 @@ with tab_zipcode:
                     with stat_cols[2]:
                         st.metric("미조회", missed)
 
-                    st.dataframe(zip_df, use_container_width=True)
+                    st.dataframe(zip_df, width="stretch")
 
                     zip_output = io.BytesIO()
                     with pd.ExcelWriter(zip_output, engine="openpyxl") as zwriter:
@@ -672,7 +672,7 @@ with tab_history:
                 if "우편번호" in hist_df.columns:
                     hist_df["우편번호"] = hist_df["우편번호"].apply(normalize_zip_code)
 
-                st.dataframe(hist_df.head(20), use_container_width=True)
+                st.dataframe(hist_df.head(20), width="stretch")
                 st.caption(f"총 {len(hist_df)}건 (최대 20건 미리보기)")
 
                 hist_output = io.BytesIO()
@@ -705,7 +705,7 @@ with tab_history:
                         mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                         type="primary",
                         key="hist_download_btn",
-                        use_container_width=True,
+                        width="stretch",
                     )
 
                 with col_dl2:
@@ -731,14 +731,14 @@ with tab_history:
                             mime="application/json",
                             type="secondary",
                             key="hist_catalog_btn",
-                            use_container_width=True,
+                            width="stretch",
                         )
                     else:
                         st.button(
                             "📋 카탈로그 정보 없음",
                             disabled=True,
                             key="hist_catalog_btn_disabled",
-                            use_container_width=True,
+                            width="stretch",
                         )
 
 # ===== 탭 5: 채팅 검색 =====

--- a/database.py
+++ b/database.py
@@ -1,4 +1,5 @@
 import json
+import math
 from datetime import datetime
 
 from supabase import create_client, Client
@@ -56,19 +57,25 @@ def save_extracted_orders(
     order_number, product, option, volume, chat_name,
     order_name, phone_number, address, search_address, zip_code
     """
+    def clean(value):
+        """pandas가 결측치를 float NaN으로 채운 경우 JSON 직렬화가 가능하도록 None으로 변환합니다."""
+        if isinstance(value, float) and math.isnan(value):
+            return None
+        return value
+
     rows = [
         {
             "job_id": job_id,
-            "order_number": o.get("order_number"),
-            "product": o.get("product"),
-            "option": o.get("option"),
-            "volume": o.get("volume"),
-            "chat_name": o.get("chat_name"),
-            "order_name": o.get("order_name"),
-            "phone_number": o.get("phone_number"),
-            "address": o.get("address"),
-            "search_address": o.get("search_address"),
-            "zip_code": o.get("zip_code"),
+            "order_number": clean(o.get("order_number")),
+            "product": clean(o.get("product")),
+            "option": clean(o.get("option")),
+            "volume": clean(o.get("volume")),
+            "chat_name": clean(o.get("chat_name")),
+            "order_name": clean(o.get("order_name")),
+            "phone_number": clean(o.get("phone_number")),
+            "address": clean(o.get("address")),
+            "search_address": clean(o.get("search_address")),
+            "zip_code": clean(o.get("zip_code")),
             "created_at": datetime.now().isoformat(),
         }
         for o in orders

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-streamlit==1.44.0
+streamlit==1.59.1
 emoji==2.15.0
-pandas==2.2.3
-google-genai==1.14.0
-pydantic==2.12.4
-openpyxl==3.1.2
+pandas==3.0.3
+google-genai==2.11.0
+pydantic==2.13.4
+openpyxl==3.1.5
 pyyaml==6.0.3
-supabase==2.28.1
+supabase==2.31.0

--- a/services.py
+++ b/services.py
@@ -113,6 +113,9 @@ def lookup_zip_code(address: str | None, juso_api_key: str) -> str | None:
 
 def format_phone_number(phone: str | None) -> str | None:
     """전화번호에서 숫자만 추출 후 010-XXXX-XXXX 형식으로 변환합니다."""
+    if phone is None or pd.isna(phone):
+        return None
+    phone = str(phone)
     if not phone:
         return phone
     digits = re.sub(r"\D", "", phone)


### PR DESCRIPTION
## Summary
- streamlit/pandas 등 네이티브 전이 의존성(pyarrow, numpy)을 현재 검증된 버전 조합으로 업그레이드하여, Streamlit Cloud의 Python 3.13.14 환경에서 발생하던 카탈로그 업로드 시 segfault를 해결
- pandas 3 업그레이드로 드러난 결측치 관련 두 가지 부수 버그를 함께 수정
  - `format_phone_number`: pandas 3 Arrow string dtype에서 결측 전화번호가 float `NaN`으로 전달되어 `re.sub`이 `TypeError`로 죽던 문제
  - `save_extracted_orders`: DataFrame 결측치(volume 등)가 `NaN`으로 남아 Supabase insert 시 `json.dumps(allow_nan=False)`에서 `ValueError`로 죽던 문제
- streamlit 1.59.1의 `use_container_width` deprecation 경고 제거 (`width="stretch"`로 교체)

## Changes
- `requirements.txt`: streamlit 1.44.0→1.59.1, pandas 2.2.3→3.0.3, google-genai 1.14.0→2.11.0, pydantic 2.12.4→2.13.4, openpyxl 3.1.2→3.1.5, supabase 2.28.1→2.31.0
- `services.py`: `format_phone_number`에 `pd.isna` 가드 추가
- `database.py`: `save_extracted_orders`에 NaN→None 정리(`clean`) 헬퍼 추가
- `app.py`: `use_container_width=True` → `width="stretch"` 전체 교체

## Root cause
자세한 분석은 #56 참고. 요약하면 `requirements.txt`가 앱이 직접 쓰는 8개 패키지만 고정하고 pyarrow/numpy 같은 네이티브 전이 의존성은 고정하지 않아, Streamlit Cloud가 매 배포마다 최신 버전(pyarrow 25.0.0, numpy 2.5.1, Python 3.13.14)을 새로 설치했고, 16개월 전 버전인 streamlit 1.44.0의 Arrow 직렬화 코드가 이 조합에서 한 번도 검증된 적이 없어 첫 `st.dataframe()` 호출(카탈로그 미리보기) 시점에 네이티브 크래시가 발생했습니다.

## Test plan
- [x] 로컬(conda `c2o`, Python 3.13.13)에 업그레이드된 버전 설치 후 카탈로그 CSV 업로드 → 미리보기 정상 표시 확인
- [x] `format_phone_number`에 결측/None/정상 전화번호 케이스를 넣어 pandas 3.0.3에서 재현 및 수정 확인
- [x] `save_extracted_orders`에 volume=None 등 결측치가 섞인 orders로 NaN→None 정리 및 `json.dumps(allow_nan=False)` 통과 확인
- [ ] Streamlit Cloud 배포 후 실제 카탈로그 업로드로 segfault 재발 여부 확인

Closes #56