### PR TITLE
refactor: separate extraction pipeline and Streamlit tabs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@
 SUPABASE_URL=
 SUPABASE_KEY=
 JUSO_API_KEY=
+# 로그인 쿠키 서명용 비밀키. 길고 무작위한 값으로 설정하세요.
+# 예) python -c "import secrets; print(secrets.token_urlsafe(32))"
+# 미설정 시 로그인은 세션에만 유지되어 웹소켓 재연결 시 로그인 화면으로 튕길 수 있습니다.
+AUTH_SECRET=

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ python -m streamlit run app.py
 export SUPABASE_URL="<SUPABASE_URL>"
 export SUPABASE_KEY="<SUPABASE_KEY>"
 export JUSO_API_KEY="<JUSO_API_KEY>"
+export AUTH_SECRET="<AUTH_SECRET>"
 python -m streamlit run app.py
 ```
 
@@ -68,6 +69,11 @@ Railway의 Streamlit 서비스에서 **Variables** 탭에 다음 변수를 등�
 | `SUPABASE_URL` | Supabase 프로젝트 URL | 웹 로그인 사용 시 필수 |
 | `SUPABASE_KEY` | Supabase API Key | 웹 로그인 사용 시 필수 |
 | `JUSO_API_KEY` | 행정안전부 도로명주소 API Key | 우편번호 조회 시 필수 |
+| `AUTH_SECRET` | 로그인 쿠키 서명용 비밀키 | 로그인 유지(권장) |
+
+> `AUTH_SECRET`은 로그인 상태를 서명 쿠키로 영속화해, 추출 도중 웹소켓이 재연결돼도
+> 로그인 화면으로 튕기지 않게 합니다. 미설정 시 로그인은 세션에만 유지됩니다.
+> `python -c "import secrets; print(secrets.token_urlsafe(32))"` 로 긴 무작위 값을 생성하세요.
 
 `.env.example`은 필요한 변수 이름을 보여주는 템플릿이며 실제 비밀값을 저장하거나 Git에 커밋하지 않습니다.
 

--- a/app.py
+++ b/app.py
@@ -1,9 +1,17 @@
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import extra_streamlit_components as stx
 import streamlit as st
 import yaml
 
-from database import authenticate_user, get_connection, get_monthly_api_call_count
+from auth import COOKIE_NAME, DEFAULT_TTL_SECONDS, issue_token, verify_token
+from database import (
+    authenticate_user,
+    get_account_by_user_id,
+    get_connection,
+    get_monthly_api_call_count,
+)
 from settings import get_env, load_prompt
 from ui import tab_catalog, tab_history, tab_order, tab_search, tab_zipcode
 from ui.common import AppContext
@@ -37,7 +45,45 @@ def monthly_api_usage(user_id: str) -> int:
     return get_monthly_api_call_count(connection, user_id) if connection else 0
 
 
-def render_login(db_conn) -> None:
+def _persist_login_cookie(cookie_manager, user_id: str) -> None:
+    """로그인 성공 시 서명 토큰을 쿠키에 저장한다. AUTH_SECRET 미설정 시 생략."""
+    secret = get_env("AUTH_SECRET")
+    if not secret:
+        return
+    token = issue_token(user_id, secret)
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=DEFAULT_TTL_SECONDS)
+    cookie_manager.set(COOKIE_NAME, token, expires_at=expires_at)
+
+
+def _clear_login_cookie(cookie_manager) -> None:
+    """로그아웃 시 인증 쿠키를 제거한다."""
+    try:
+        cookie_manager.delete(COOKIE_NAME)
+    except KeyError:
+        pass
+
+
+def _restore_login_from_cookie(cookie_manager, db_conn) -> None:
+    """세션이 비어 있을 때 쿠키의 서명 토큰으로 로그인 상태를 복원한다.
+
+    웹소켓 재연결 등으로 session_state가 초기화돼도 로그인 화면으로 튕기지 않도록
+    한다. 토큰 서명·만료를 검증한 뒤 DB에서 현재 계정 상태를 다시 읽어온다.
+    """
+    secret = get_env("AUTH_SECRET")
+    if not secret or not db_conn:
+        return
+    user_id = verify_token(cookie_manager.get(COOKIE_NAME), secret)
+    if not user_id:
+        return
+    account = get_account_by_user_id(db_conn, user_id)
+    if not account:
+        return
+    st.session_state["api_key"] = account["gemini_api_key"]
+    st.session_state["monthly_extract_limit"] = account["monthly_extract_limit"]
+    st.session_state["logged_in_user"] = user_id
+
+
+def render_login(db_conn, cookie_manager) -> None:
     _, center, _ = st.columns([1, 2, 1])
     with center:
         st.markdown(
@@ -67,15 +113,17 @@ def render_login(db_conn) -> None:
         st.session_state["api_key"] = account["gemini_api_key"]
         st.session_state["monthly_extract_limit"] = account["monthly_extract_limit"]
         st.session_state["logged_in_user"] = email
+        _persist_login_cookie(cookie_manager, email)
         st.rerun()
 
 
-def render_sidebar(ctx: AppContext) -> None:
+def render_sidebar(ctx: AppContext, cookie_manager) -> None:
     with st.sidebar:
         st.write(f"👤 **{ctx.user_id}**님 환영합니다.")
         if st.button("LogOut"):
             st.session_state["logged_in_user"] = None
             st.session_state["api_key"] = None
+            _clear_login_cookie(cookie_manager)
             st.rerun()
         st.divider()
         st.header("Account State")
@@ -98,13 +146,17 @@ def main() -> None:
         f"<style>{load_static_text('styles/main.css')}</style>",
         unsafe_allow_html=True,
     )
+    cookie_manager = stx.CookieManager()
     db_conn = get_db()
     st.session_state.setdefault("logged_in_user", None)
     st.session_state.setdefault("api_key", None)
     st.session_state.setdefault("monthly_extract_limit", None)
 
     if not st.session_state["logged_in_user"]:
-        render_login(db_conn)
+        _restore_login_from_cookie(cookie_manager, db_conn)
+
+    if not st.session_state["logged_in_user"]:
+        render_login(db_conn, cookie_manager)
         st.stop()
 
     config = load_config()
@@ -117,7 +169,7 @@ def main() -> None:
         order_extraction_prompt=cached_prompt(config["prompts"]["order_extraction"]),
         address_to_search_prompt=cached_prompt(config["prompts"]["address_to_search"]),
     )
-    render_sidebar(ctx)
+    render_sidebar(ctx, cookie_manager)
     st.markdown(
         "## 📦 <span style='color:#FF6B35;font-weight:bold;'>C</span>hat"
         "<span style='color:#FF6B35;font-weight:bold;'>2O</span>rder",

--- a/app.py
+++ b/app.py
@@ -1,970 +1,152 @@
-import io
-import json
-import datetime
 from pathlib import Path
-import yaml
-import pandas as pd
+
 import streamlit as st
+import yaml
 
+from database import authenticate_user, get_connection, get_monthly_api_call_count
 from settings import get_env, load_prompt
+from ui import tab_catalog, tab_history, tab_order, tab_search, tab_zipcode
+from ui.common import AppContext
 
-from services import (
-    parse_catalog_json,
-    generate_catalog_from_csv,
-    parse_csv,
-    extract_orders_from_chat,
-    resolve_extracted_items,
-    lookup_zip_code,
-    format_phone_number,
-    normalize_zip_code,
-    batch_lookup_zip_codes,
-    extract_chat_name,
-    search_keyword_in_raw_csv,
-)
-from database import (
-    get_connection,
-    authenticate_user,
-    create_extraction_job,
-    update_extraction_job_total,
-    save_extracted_orders,
-    save_unresolved_items,
-    save_training_record,
-    save_extract_call_log,
-    get_monthly_api_call_count,
-    get_jobs_by_user,
-    get_orders_by_job,
-    get_catalog_by_job,
-    save_raw_chat_files,
-    get_raw_files_by_job,
-)
 
-MAPPING_STATUS_LABELS = {
-    "exact": "✅ 확정",
-    "alias": "✅ 확정",
-    "typo": "🔧 자동보정",
-    "inferred": "🔧 자동보정",
-}
+@st.cache_resource
+def get_db():
+    url = get_env("SUPABASE_URL")
+    key = get_env("SUPABASE_KEY")
+    return get_connection(url, key) if url and key else None
 
-# --- UI 구성 ---
-st.set_page_config(page_title="Chat2Order: Convert Chat to Order", layout="wide")
 
-with open("styles/main.css", encoding="utf-8") as css_file:
-    st.markdown(f"<style>{css_file.read()}</style>", unsafe_allow_html=True)
+@st.cache_data
+def load_config(path: str = "config.yaml") -> dict:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
 
-# --- DB 연결 (로그인 전에 초기화 필요) ---
-supabase_url = get_env("SUPABASE_URL")
-supabase_key = get_env("SUPABASE_KEY")
-db_conn = (
-    get_connection(supabase_url, supabase_key)
-    if supabase_url and supabase_key
-    else None
-)
 
-if "logged_in_user" not in st.session_state:
-    st.session_state["logged_in_user"] = None
-if "api_key" not in st.session_state:
-    st.session_state["api_key"] = None
-if "monthly_extract_limit" not in st.session_state:
-    st.session_state["monthly_extract_limit"] = None
+@st.cache_data
+def load_static_text(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
 
-if not st.session_state["logged_in_user"]:
-    col_left, col_center, col_right = st.columns([1, 2, 1])
-    with col_center:
+
+@st.cache_data
+def cached_prompt(path: str) -> str:
+    return load_prompt(path)
+
+
+@st.cache_data(ttl=60)
+def monthly_api_usage(user_id: str) -> int:
+    connection = get_db()
+    return get_monthly_api_call_count(connection, user_id) if connection else 0
+
+
+def render_login(db_conn) -> None:
+    _, center, _ = st.columns([1, 2, 1])
+    with center:
         st.markdown(
             """
-        <div style="text-align:center; padding:2rem 0;">
-            <h1 style="color:#FF6B35;">Chat2Order</h1>
-            <p style="color:#888;">로그인하여 시작하세요</p>
-        </div>
-        """,
+            <div style="text-align:center; padding:2rem 0;">
+              <h1 style="color:#FF6B35;">Chat2Order</h1>
+              <p style="color:#888;">로그인하여 시작하세요</p>
+            </div>
+            """,
             unsafe_allow_html=True,
         )
         with st.form("login_form"):
             email = st.text_input("이메일")
             password = st.text_input("비밀번호", type="password")
-            submit_button = st.form_submit_button(
+            submitted = st.form_submit_button(
                 "LogIn", width="stretch", type="primary"
             )
-
-            if submit_button:
-                if not db_conn:
-                    st.error("DB 연결이 설정되지 않았습니다. 관리자에게 문의하세요.")
-                else:
-                    account_info = authenticate_user(
-                        db_conn, user_id=email, password=password
-                    )
-                    if account_info:
-                        st.session_state["api_key"] = account_info["gemini_api_key"]
-                        st.session_state["monthly_extract_limit"] = account_info[
-                            "monthly_extract_limit"
-                        ]
-                        st.session_state["logged_in_user"] = email
-                        st.rerun()
-                    else:
-                        st.error(
-                            "이메일/비밀번호가 올바르지 않거나 비활성화된 계정입니다."
-                        )
-    st.stop()  # 로그인되지 않은 경우 아래 메인 앱 코드 실행 방지
-
-# 로그인된 사용자 표시 및 로그아웃 버튼 (사이드바)
-with st.sidebar:
-    st.write(f"👤 **{st.session_state['logged_in_user']}**님 환영합니다.")
-    if st.button("LogOut"):
-        st.session_state["logged_in_user"] = None
+        if not submitted:
+            return
+        if not db_conn:
+            st.error("DB 연결이 설정되지 않았습니다. 관리자에게 문의하세요.")
+            return
+        account = authenticate_user(db_conn, user_id=email, password=password)
+        if not account:
+            st.error("이메일/비밀번호가 올바르지 않거나 비활성화된 계정입니다.")
+            return
+        st.session_state["api_key"] = account["gemini_api_key"]
+        st.session_state["monthly_extract_limit"] = account["monthly_extract_limit"]
+        st.session_state["logged_in_user"] = email
         st.rerun()
-    st.divider()
 
 
-# --- 설정 파일 로드 ---
-with open("config.yaml", "r", encoding="utf-8") as f:
-    config = yaml.safe_load(f)
-
-st.markdown(
-    "## 📦 <span style='color:#FF6B35;font-weight:bold;'>C</span>hat<span style='color:#FF6B35;font-weight:bold;'>2O</span>rder",
-    unsafe_allow_html=True,
-)
-st.markdown(
-    "사장님은 소통에만 집중하세요. 대화 속 주문 정리는 C2O가 알아서 엑셀로 만들어 드립니다.",
-    unsafe_allow_html=True,
-)
-
-juso_api_key = get_env("JUSO_API_KEY")
-order_extraction_prompt = load_prompt(config["prompts"]["order_extraction"])
-address_to_search_prompt = load_prompt(config["prompts"]["address_to_search"])
-
-# 사이드바: API 키 상태 표시
-with st.sidebar:
-    st.header("Account State")
-    if st.session_state.get("api_key"):
-        st.success("✅ 관리자 승인 완료")  # gemini api key 연동 완료
-    else:
-        st.error("❌ API Key 연동 실패")
-
-    monthly_limit = st.session_state.get("monthly_extract_limit")
-    if db_conn:
-        monthly_used = get_monthly_api_call_count(
-            db_conn, st.session_state["logged_in_user"]
-        )
-        if monthly_limit is None:
-            st.info(f"이번 달 사용량: {monthly_used} / 무제한")
+def render_sidebar(ctx: AppContext) -> None:
+    with st.sidebar:
+        st.write(f"👤 **{ctx.user_id}**님 환영합니다.")
+        if st.button("LogOut"):
+            st.session_state["logged_in_user"] = None
+            st.session_state["api_key"] = None
+            st.rerun()
+        st.divider()
+        st.header("Account State")
+        if ctx.api_key:
+            st.success("✅ 관리자 승인 완료")
         else:
-            st.info(f"이번 달 사용량: {monthly_used} / {monthly_limit}")
+            st.error("❌ API Key 연동 실패")
 
-# --- 탭 구성 ---
-tab_order, tab_catalog, tab_zipcode, tab_history, tab_search = st.tabs(
-    [
-        "📦 주문서 추출",
-        "📋 카탈로그 생성",
-        "📮 우편번호 추출",
-        "🗂️ 나의 추출 이력",
-        "🔎 채팅 검색",
-    ]
-)
-
-# ===== 탭 1: 주문서 추출 (기존 기능) =====
-with tab_order:
-    col1, col2 = st.columns(2)
-    with col1:
-        st.markdown(
-            '<span class="step-badge">1</span> **카탈로그 업로드**',
-            unsafe_allow_html=True,
-        )
-        catalog_file = st.file_uploader(
-            "카탈로그를 업로드하세요.",
-            type=["json"],
+        used = monthly_api_usage(ctx.user_id) if ctx.db_conn else 0
+        limit = st.session_state.get("monthly_extract_limit")
+        st.info(
+            f"이번 달 사용량: {used} / "
+            f"{'무제한' if limit is None else limit}"
         )
 
-    with col2:
-        st.markdown(
-            '<span class="step-badge">2</span> **대화 내역 업로드**',
-            unsafe_allow_html=True,
-        )
-        if "chat_uploader_key" not in st.session_state:
-            st.session_state["chat_uploader_key"] = 0
-        chat_files = st.file_uploader(
-            "카카오톡 대화 파일들을 업로드하세요.",
-            type=["csv"],
-            accept_multiple_files=True,
-            key=f"chat_uploader_{st.session_state['chat_uploader_key']}",
-        )
 
-        if chat_files:
-            name_groups = {}
-            for f in chat_files:
-                content = f.read()
-                f.seek(0)
-                name_groups.setdefault(f.name, [])
-                # 같은 이름+같은 내용이면 중복 제거
-                if not any(content == existing for existing, _ in name_groups[f.name]):
-                    name_groups[f.name].append((content, f))
-
-            unique_files = []
-            display_names = {}
-            for name, entries in name_groups.items():
-                if len(entries) == 1:
-                    unique_files.append(entries[0][1])
-                    display_names[id(entries[0][1])] = name
-                else:
-                    stem = Path(name).stem
-                    suffix = Path(name).suffix
-                    for idx, (_, f) in enumerate(entries, start=1):
-                        display_names[id(f)] = f"{stem}({idx}){suffix}"
-                        unique_files.append(f)
-            chat_files = unique_files
-            st.session_state["chat_display_names"] = display_names
-            with st.expander(f"📁 업로드된 파일 {len(chat_files)}개 보기"):
-                for f in chat_files:
-                    st.write(f"• {display_names.get(id(f), f.name)}")
-            if st.button("❌ 업로드 파일 전체 삭제", key="clear_chat_files"):
-                st.session_state["chat_uploader_key"] += 1
-                st.rerun()
-
+def main() -> None:
+    st.set_page_config(page_title="Chat2Order: Convert Chat to Order", layout="wide")
     st.markdown(
-        '<span class="step-badge">3</span> **라이브쇼핑 시간 입력**',
+        f"<style>{load_static_text('styles/main.css')}</style>",
         unsafe_allow_html=True,
     )
-    start_col1, start_col2, end_col1, end_col2 = st.columns(4)
-    with start_col1:
-        start_date = st.date_input("시작 날짜")
-    with start_col2:
-        start_time = st.time_input("시작 시간")
-    with end_col1:
-        end_date = st.date_input("종료 날짜", value=start_date)
-    with end_col2:
-        end_time = st.time_input("종료 시간", value=datetime.time(23, 59))
-    time_after = datetime.datetime.combine(start_date, start_time)
-    time_before = datetime.datetime.combine(end_date, end_time)
+    db_conn = get_db()
+    st.session_state.setdefault("logged_in_user", None)
+    st.session_state.setdefault("api_key", None)
+    st.session_state.setdefault("monthly_extract_limit", None)
 
-    if st.button("🚀 주문서 추출 실행", type="primary", width="stretch"):
-        if not st.session_state.get("api_key"):
-            st.warning("API Key가 할당되지 않았습니다. 관리자에게 문의하세요.")
-        elif not catalog_file:
-            st.warning("카탈로그 파일을 업로드해 주세요.")
-        elif not chat_files:
-            st.warning("대화 내역 파일을 1개 이상 업로드해 주세요.")
-        else:
-            monthly_limit = st.session_state.get("monthly_extract_limit")
-            files_to_process = chat_files
-            if db_conn and monthly_limit is not None:
-                monthly_used = get_monthly_api_call_count(
-                    db_conn, st.session_state["logged_in_user"]
-                )
-                remaining = monthly_limit - monthly_used
-                if remaining <= 0:
-                    st.error(
-                        f"이번 달 API 호출 한도({monthly_limit}회)를 모두 사용했습니다. "
-                        "다음 달 1일에 초기화됩니다."
-                    )
-                    st.stop()
-                elif len(chat_files) > remaining:
-                    st.warning(
-                        f"이번 달 남은 한도가 {remaining}회입니다. "
-                        f"파일 {len(chat_files)}개 중 {remaining}개만 처리합니다."
-                    )
-                    files_to_process = chat_files[:remaining]
+    if not st.session_state["logged_in_user"]:
+        render_login(db_conn)
+        st.stop()
 
-            with st.status("주문서 추출 중입니다", expanded=True) as status:
-                st.write("📋 카탈로그를 파싱 중")
-                catalog_data = parse_catalog_json(catalog_file)
-                all_extracted_orders = []
-                all_unresolved_rows = []
-                raw_files_buffer = []
-
-                job_id = None
-                if db_conn:
-                    job_id = create_extraction_job(
-                        conn=db_conn,
-                        user_id=st.session_state["logged_in_user"],
-                        title=datetime.datetime.now().strftime("%Y%m%d_%H%M%S"),
-                        live_start_time=time_after,
-                        model=config["gemini"]["model"],
-                    )
-
-                today_str = datetime.date.today().strftime("%Y%m%d")
-                seq = 1
-                total_files = len(files_to_process)
-                progress_text = st.empty()
-                progress_bar = st.progress(0)
-                display_names = st.session_state.get("chat_display_names", {})
-                for i, chat_file in enumerate(files_to_process):
-                    file_display = display_names.get(id(chat_file), chat_file.name)
-                    progress_text.write(f"💬 채팅 내역 분석 중 ({i}/{total_files})")
-                    chat_data, ts = parse_csv(
-                        chat_file,
-                        filename_prefix=config["csv"]["filename_prefix"],
-                        exclude_messages=config["csv"]["exclude_messages"],
-                        time_after=time_after,
-                        time_before=time_before,
-                    )
-
-                    # 원본 CSV를 키워드 검색용으로 보관 (탭 "채팅 검색")
-                    raw_files_buffer.append(
-                        {
-                            "filename": file_display,
-                            "chat_name": extract_chat_name(
-                                file_display,
-                                filename_prefix=config["csv"]["filename_prefix"],
-                            ),
-                            "content": chat_file.getvalue().decode(
-                                "utf-8-sig", errors="replace"
-                            ),
-                            "message_count": len(chat_data),
-                        }
-                    )
-
-                    try:
-                        extracted_data = extract_orders_from_chat(
-                            st.session_state["api_key"],
-                            catalog_data,
-                            chat_data,
-                            model=config["gemini"]["model"],
-                            temperature=config["gemini"]["temperature"],
-                            prompt_template=order_extraction_prompt,
-                        )
-                        if db_conn and job_id:
-                            save_extract_call_log(
-                                conn=db_conn,
-                                user_id=st.session_state["logged_in_user"],
-                                job_id=job_id,
-                                chat_filename=file_display,
-                            )
-                    except RuntimeError as e:
-                        st.error(str(e))
-                        extracted_data = None
-
-                    if extracted_data:
-                        if db_conn and job_id:
-                            save_training_record(
-                                conn=db_conn,
-                                job_id=job_id,
-                                user_id=st.session_state["logged_in_user"],
-                                chat_filename=file_display,
-                                catalog_data=catalog_data,
-                                chat_data=chat_data,
-                                predicted_json=extracted_data,
-                            )
-                        items = extracted_data.get("items", [])
-                        if items:
-                            chat_name = extract_chat_name(
-                                file_display,
-                                filename_prefix=config["csv"]["filename_prefix"],
-                            )
-                            order_number = f"{today_str}{seq:03d}"
-                            # LLM이 반환한 product/option은 힌트일 뿐이며, 최종 확정은
-                            # 항상 CatalogResolver를 통과시킨다 (issue #61).
-                            resolved_items = resolve_extracted_items(
-                                items, catalog_data
-                            )
-                            for resolved in resolved_items:
-                                if resolved.mapping_status == "unresolved":
-                                    all_unresolved_rows.append(
-                                        {
-                                            "chat_name": chat_name,
-                                            "raw_product": resolved.raw_product,
-                                            "raw_option": resolved.raw_option,
-                                            "volume": resolved.volume,
-                                            "candidate_products": resolved.candidate_products,
-                                            "mapping_reason": resolved.mapping_reason,
-                                            "order_name": extracted_data.get(
-                                                "order_name"
-                                            ),
-                                            "phone_number": extracted_data.get(
-                                                "phone_number"
-                                            ),
-                                            "address": extracted_data.get("address"),
-                                        }
-                                    )
-                                    continue
-                                row = {
-                                    "product": resolved.product,
-                                    "option": resolved.option,
-                                    "volume": resolved.volume,
-                                    "raw_product": resolved.raw_product,
-                                    "raw_option": resolved.raw_option,
-                                    "mapping_status": resolved.mapping_status,
-                                    "order_name": extracted_data.get("order_name"),
-                                    "phone_number": extracted_data.get("phone_number"),
-                                    "address": extracted_data.get("address"),
-                                    "search_address": extracted_data.get(
-                                        "search_address"
-                                    ),
-                                    "time": ts,
-                                    "chat_name": chat_name,
-                                    "live_time": time_after,
-                                    "order_number": order_number,
-                                }
-                                all_extracted_orders.append(row)
-                            seq += 1
-
-                    progress_bar.progress((i + 1) / total_files)
-                    progress_text.write(f"💬 채팅 내역 분석 중 ({i + 1}/{total_files})")
-
-                if db_conn and job_id and raw_files_buffer:
-                    save_raw_chat_files(
-                        conn=db_conn,
-                        job_id=job_id,
-                        user_id=st.session_state["logged_in_user"],
-                        files=raw_files_buffer,
-                    )
-
-                if db_conn and job_id and all_unresolved_rows:
-                    save_unresolved_items(
-                        conn=db_conn,
-                        job_id=job_id,
-                        items=all_unresolved_rows,
-                    )
-
-                if juso_api_key:
-                    st.write("📮 우편번호 조회 중")
-
-                status.update(
-                    label="🎉 주문 데이터 추출이 완료되었습니다!", state="complete"
-                )
-
-            unresolved_df = pd.DataFrame(all_unresolved_rows, dtype=object)
-            if not unresolved_df.empty and "candidate_products" in unresolved_df.columns:
-                # openpyxl은 list 셀 값을 쓸 수 없으므로 표시/저장 전 문자열로 변환
-                unresolved_df["candidate_products"] = unresolved_df[
-                    "candidate_products"
-                ].apply(lambda v: ", ".join(v) if isinstance(v, list) else (v or ""))
-
-            if all_extracted_orders:
-                df = pd.DataFrame(all_extracted_orders, dtype=object)
-                df["phone_number"] = df["phone_number"].apply(format_phone_number)
-                if "zip_code" in df.columns:
-                    df["zip_code"] = df["zip_code"].apply(normalize_zip_code)
-
-                if juso_api_key:
-                    df["zip_code"] = df["search_address"].apply(
-                        lambda addr: lookup_zip_code(addr, juso_api_key)
-                    )
-                    df["zip_code"] = df["zip_code"].apply(normalize_zip_code)
-
-                if db_conn and job_id:
-                    save_extracted_orders(
-                        conn=db_conn,
-                        job_id=job_id,
-                        orders=df.to_dict("records"),
-                    )
-                    update_extraction_job_total(
-                        conn=db_conn,
-                        job_id=job_id,
-                        total_orders=len(df),
-                    )
-
-                col_map = config["output_columns"]
-                rename = {v: k for k, v in col_map.items() if v}
-
-                # 화면 표시용: 매핑 상태(확정/자동보정)와 원문 대조 컬럼을 추가한 사본.
-                # 발주용 Excel 본시트 양식(9컬럼 고정)에는 영향을 주지 않는다.
-                display_df = df.copy()
-                display_df["매핑"] = (
-                    display_df["mapping_status"]
-                    .map(MAPPING_STATUS_LABELS)
-                    .fillna("✅ 확정")
-                )
-                display_df["원문"] = display_df.apply(
-                    lambda r: (
-                        f"{r.get('raw_product') or ''} {r.get('raw_option') or ''}".strip()
-                        if r.get("mapping_status") in ("typo", "inferred")
-                        else ""
-                    ),
-                    axis=1,
-                )
-                display_df = display_df.rename(columns=rename)
-                display_df = display_df.reindex(
-                    columns=list(col_map.keys()) + ["매핑", "원문"], fill_value=""
-                )
-                st.dataframe(display_df, width="stretch")
-
-                # 저장/다운로드용: 기존 발주 양식 그대로 유지.
-                df = df.rename(columns=rename)
-                df = df.reindex(columns=list(col_map.keys()), fill_value="")
-
-                output = io.BytesIO()
-                with pd.ExcelWriter(
-                    output, engine="openpyxl", datetime_format="YYYY-MM-DD HH:MM:SS"
-                ) as writer:
-                    df.to_excel(
-                        writer, index=False, sheet_name=config["output"]["sheet_name"]
-                    )
-                    worksheet = writer.sheets[config["output"]["sheet_name"]]
-                    if "우편번호" in df.columns:
-                        zip_col_idx = df.columns.get_loc("우편번호") + 1
-                        for row in worksheet.iter_rows(
-                            min_row=2,
-                            max_row=worksheet.max_row,
-                            min_col=zip_col_idx,
-                            max_col=zip_col_idx,
-                        ):
-                            row[0].number_format = "@"
-
-                    if not unresolved_df.empty:
-                        unresolved_df.to_excel(
-                            writer, index=False, sheet_name="검토필요"
-                        )
-
-                st.download_button(
-                    label="📥 엑셀 파일(.xlsx) 다운로드",
-                    data=output.getvalue(),
-                    file_name=config["output"]["file_name"],
-                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    type="primary",
-                )
-            elif unresolved_df.empty:
-                st.error(
-                    "추출된 데이터가 없습니다. 원본 데이터나 API 상태를 확인해 주세요."
-                )
-
-            if not unresolved_df.empty:
-                st.warning(
-                    f"⚠️ {len(unresolved_df)}건은 자동 매핑에 실패하여 검토가 필요합니다. "
-                    "임의로 확정하지 않았으니 아래 내역을 확인해 주세요."
-                )
-                st.dataframe(
-                    unresolved_df[
-                        [
-                            "chat_name",
-                            "raw_product",
-                            "raw_option",
-                            "volume",
-                            "candidate_products",
-                            "mapping_reason",
-                        ]
-                    ],
-                    width="stretch",
-                )
-
-# ===== 탭 2: 카탈로그 생성 =====
-with tab_catalog:
-    st.markdown(
-        '<span class="step-badge">1</span> **재고 CSV 업로드**', unsafe_allow_html=True
+    config = load_config()
+    ctx = AppContext(
+        db_conn=db_conn,
+        config=config,
+        api_key=st.session_state.get("api_key") or "",
+        user_id=st.session_state["logged_in_user"],
+        juso_api_key=get_env("JUSO_API_KEY"),
+        order_extraction_prompt=cached_prompt(config["prompts"]["order_extraction"]),
+        address_to_search_prompt=cached_prompt(config["prompts"]["address_to_search"]),
     )
-    stk_csv_file = st.file_uploader(
-        "CSV 파일을 업로드하세요. (상품명·옵션내용 컬럼 필요)",
-        type=["csv"],
-        key="catalog_csv_uploader",
-    )
-
-    if stk_csv_file:
-        try:
-            catalog_dict = generate_catalog_from_csv(stk_csv_file)
-        except ValueError as e:
-            st.error(str(e))
-            st.stop()
-
-        st.markdown(
-            '<span class="step-badge">2</span> **미리보기 및 확인**',
-            unsafe_allow_html=True,
-        )
-
-        total_products = len(catalog_dict)
-        total_options = sum(len(opts) for opts in catalog_dict.values())
-        single_products = sum(
-            1 for opts in catalog_dict.values() if opts == ["단일상품"]
-        )
-
-        stat_cols = st.columns(3)
-        with stat_cols[0]:
-            st.metric("총 상품 수", total_products)
-        with stat_cols[1]:
-            st.metric("총 옵션 수", total_options)
-        with stat_cols[2]:
-            st.metric("단일상품", single_products)
-
-        preview_rows = []
-        for product, options in catalog_dict.items():
-            preview_rows.append(
-                {
-                    "상품명": product,
-                    "옵션": ", ".join(options),
-                    "옵션 수": len(options),
-                }
-            )
-        preview_df = pd.DataFrame(preview_rows, dtype=object)
-        preview_df.index = preview_df.index + 1
-        preview_df.index.name = "#"
-        st.dataframe(preview_df, width="stretch")
-
-        st.markdown(
-            '<span class="step-badge">3</span> **카탈로그 다운로드**',
-            unsafe_allow_html=True,
-        )
-
-        catalog_json_str = json.dumps(catalog_dict, ensure_ascii=False, indent=2)
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-
-        st.download_button(
-            label="📥 catalog.json 다운로드",
-            data=catalog_json_str.encode("utf-8"),
-            file_name=f"catalog_{timestamp}.json",
-            mime="application/json",
-            type="primary",
-            width="stretch",
-        )
-
-# ===== 탭 3: 우편번호 추출 =====
-with tab_zipcode:
+    render_sidebar(ctx)
     st.markdown(
-        '<span class="step-badge">1</span> **엑셀 파일 업로드**',
+        "## 📦 <span style='color:#FF6B35;font-weight:bold;'>C</span>hat"
+        "<span style='color:#FF6B35;font-weight:bold;'>2O</span>rder",
         unsafe_allow_html=True,
     )
-    zip_excel_file = st.file_uploader(
-        "주소 컬럼이 포함된 엑셀 파일을 업로드하세요.",
-        type=["xlsx", "xls"],
-        key="zip_excel_uploader",
+    st.markdown(
+        "사장님은 소통에만 집중하세요. 대화 속 주문 정리는 C2O가 알아서 엑셀로 만들어 드립니다."
     )
 
-    if zip_excel_file:
-        zip_df = pd.read_excel(zip_excel_file)
-        if "주소" not in zip_df.columns:
-            st.error(
-                f"'주소' 컬럼을 찾을 수 없습니다. 발견된 컬럼: {list(zip_df.columns)}"
-            )
-        else:
-            st.markdown(
-                '<span class="step-badge">2</span> **미리보기**',
-                unsafe_allow_html=True,
-            )
-            has_zip_col = "우편번호" in zip_df.columns
-            if has_zip_col:
-                st.info(
-                    "파일에 이미 '우편번호' 컬럼이 있습니다. 조회 결과로 덮어씁니다."
-                )
-            st.dataframe(zip_df.head(10), width="stretch")
-            st.caption(f"총 {len(zip_df)}건")
+    tabs = st.tabs(
+        [
+            "📦 주문서 추출",
+            "📋 카탈로그 생성",
+            "📮 우편번호 추출",
+            "🗂️ 나의 추출 이력",
+            "🔎 채팅 검색",
+        ]
+    )
+    renderers = (
+        tab_order.render,
+        tab_catalog.render,
+        tab_zipcode.render,
+        tab_history.render,
+        tab_search.render,
+    )
+    for tab, renderer in zip(tabs, renderers):
+        with tab:
+            renderer(ctx)
 
-            if st.button(
-                "📮 우편번호 조회 실행",
-                type="primary",
-                width="stretch",
-                key="zip_lookup_btn",
-            ):
-                if not st.session_state.get("api_key"):
-                    st.warning("API Key가 할당되지 않았습니다. 관리자에게 문의하세요.")
-                elif not juso_api_key:
-                    st.warning("도로명주소 API 키가 설정되지 않았습니다.")
-                else:
-                    with st.status("우편번호 조회 중입니다", expanded=True) as zstatus:
-                        progress_text = st.empty()
-                        progress_bar = st.progress(0)
-                        total = len(zip_df)
 
-                        def _progress(idx, total_count):
-                            pct = min((idx + 1) / total_count, 1.0)
-                            progress_bar.progress(pct)
-                            progress_text.write(
-                                f"📮 우편번호 조회 중... ({idx + 1}/{total_count})"
-                            )
-
-                        result_series = batch_lookup_zip_codes(
-                            df=zip_df,
-                            address_col="주소",
-                            juso_api_key=juso_api_key,
-                            api_key=st.session_state["api_key"],
-                            model=config["gemini"]["model"],
-                            temperature=config["gemini"]["temperature"],
-                            prompt_template=address_to_search_prompt,
-                            progress_callback=_progress,
-                        )
-                        if has_zip_col:
-                            zip_df["우편번호"] = result_series
-                        else:
-                            addr_pos = zip_df.columns.get_loc("주소")
-                            zip_df.insert(addr_pos + 1, "우편번호", result_series)
-
-                        found = (zip_df["우편번호"] != "").sum()
-                        zstatus.update(
-                            label=f"🎉 우편번호 조회 완료! ({found}/{total}건 성공)",
-                            state="complete",
-                        )
-
-                    st.markdown(
-                        '<span class="step-badge">3</span> **결과 확인 및 다운로드**',
-                        unsafe_allow_html=True,
-                    )
-
-                    found = (zip_df["우편번호"] != "").sum()
-                    missed = total - found
-                    stat_cols = st.columns(3)
-                    with stat_cols[0]:
-                        st.metric("전체", total)
-                    with stat_cols[1]:
-                        st.metric("성공", found)
-                    with stat_cols[2]:
-                        st.metric("미조회", missed)
-
-                    st.dataframe(zip_df, width="stretch")
-
-                    zip_output = io.BytesIO()
-                    with pd.ExcelWriter(zip_output, engine="openpyxl") as zwriter:
-                        zip_df.to_excel(zwriter, index=False, sheet_name="Sheet1")
-                        zws = zwriter.sheets["Sheet1"]
-                        if "우편번호" in zip_df.columns:
-                            zcol = zip_df.columns.get_loc("우편번호") + 1
-                            for row in zws.iter_rows(
-                                min_row=2,
-                                max_row=zws.max_row,
-                                min_col=zcol,
-                                max_col=zcol,
-                            ):
-                                row[0].number_format = "@"
-
-                    original_name = Path(zip_excel_file.name).stem
-                    st.download_button(
-                        label="📥 엑셀 파일(.xlsx) 다운로드",
-                        data=zip_output.getvalue(),
-                        file_name=f"{original_name}_우편번호.xlsx",
-                        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                        type="primary",
-                        key="zip_download_btn",
-                    )
-
-# ===== 탭 4: 추출 이력 =====
-with tab_history:
-    if not db_conn:
-        st.warning("DB 연결이 설정되지 않아 이력을 불러올 수 없습니다.")
-    else:
-        jobs = get_jobs_by_user(
-            conn=db_conn,
-            user_id=st.session_state["logged_in_user"],
-        )
-
-        if not jobs:
-            st.info("저장된 추출 이력이 없습니다.")
-        else:
-            job_labels = []
-            for j in jobs:
-                live_str = (
-                    j["live_start_time"][:16].replace("T", " ")
-                    if j.get("live_start_time")
-                    else "-"
-                )
-                job_labels.append(
-                    f"{j['title']}  |  라이브: {live_str}  |  {j['total_orders']}건"
-                )
-
-            selected_idx = st.radio(
-                "다운로드할 이력을 선택하세요 (최근 5건)",
-                options=range(len(jobs)),
-                format_func=lambda i: job_labels[i],
-            )
-
-            selected_job = jobs[selected_idx]
-            orders = get_orders_by_job(conn=db_conn, job_id=selected_job["id"])
-
-            if not orders:
-                st.info("해당 이력에 저장된 주문 데이터가 없습니다.")
-            else:
-                hist_df = pd.DataFrame(orders, dtype=object)
-                hist_df = hist_df.drop(
-                    columns=[
-                        c
-                        for c in ["id", "job_id", "created_at"]
-                        if c in hist_df.columns
-                    ]
-                )
-
-                col_map = config["output_columns"]
-                rename = {v: k for k, v in col_map.items() if v}
-                hist_df = hist_df.rename(columns=rename)
-                hist_df = hist_df.reindex(columns=list(col_map.keys()), fill_value="")
-
-                if "우편번호" in hist_df.columns:
-                    hist_df["우편번호"] = hist_df["우편번호"].apply(normalize_zip_code)
-
-                st.dataframe(hist_df.head(20), width="stretch")
-                st.caption(f"총 {len(hist_df)}건 (최대 20건 미리보기)")
-
-                hist_output = io.BytesIO()
-                with pd.ExcelWriter(
-                    hist_output,
-                    engine="openpyxl",
-                    datetime_format="YYYY-MM-DD HH:MM:SS",
-                ) as writer:
-                    hist_df.to_excel(
-                        writer, index=False, sheet_name=config["output"]["sheet_name"]
-                    )
-                    worksheet = writer.sheets[config["output"]["sheet_name"]]
-                    if "우편번호" in hist_df.columns:
-                        zip_col_idx = hist_df.columns.tolist().index("우편번호") + 1
-                        for row in worksheet.iter_rows(
-                            min_row=2,
-                            max_row=worksheet.max_row,
-                            min_col=zip_col_idx,
-                            max_col=zip_col_idx,
-                        ):
-                            row[0].number_format = "@"
-
-                col_dl1, col_dl2 = st.columns(2)
-
-                with col_dl1:
-                    st.download_button(
-                        label="📥 엑셀 파일(.xlsx) 다운로드",
-                        data=hist_output.getvalue(),
-                        file_name=f"{selected_job['title']}.xlsx",
-                        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                        type="primary",
-                        key="hist_download_btn",
-                        width="stretch",
-                    )
-
-                with col_dl2:
-                    catalog_json_str = get_catalog_by_job(
-                        conn=db_conn, job_id=selected_job["id"]
-                    )
-                    if catalog_json_str:
-                        # DB에는 [{"상품명": ..., "옵션": [...]}] list 형식으로 저장되어 있으므로
-                        # 실제 사용 형식인 {"상품명": [옵션...]} dict으로 역변환
-                        catalog_list = json.loads(catalog_json_str)
-                        catalog_dict = {
-                            item["상품명"]: item["옵션"] for item in catalog_list
-                        }
-                        formatted = json.dumps(
-                            catalog_dict,
-                            ensure_ascii=False,
-                            indent=2,
-                        )
-                        st.download_button(
-                            label="📋 카탈로그(.json) 다운로드",
-                            data=formatted.encode("utf-8"),
-                            file_name=f"catalog_{selected_job['title']}.json",
-                            mime="application/json",
-                            type="secondary",
-                            key="hist_catalog_btn",
-                            width="stretch",
-                        )
-                    else:
-                        st.button(
-                            "📋 카탈로그 정보 없음",
-                            disabled=True,
-                            key="hist_catalog_btn_disabled",
-                            width="stretch",
-                        )
-
-# ===== 탭 5: 채팅 검색 =====
-with tab_search:
-    if not db_conn:
-        st.warning("DB 연결이 설정되지 않아 검색할 수 없습니다.")
-    else:
-        jobs = get_jobs_by_user(
-            conn=db_conn,
-            user_id=st.session_state["logged_in_user"],
-        )
-
-        if not jobs:
-            st.info("저장된 추출 이력이 없습니다. 먼저 주문서 추출을 실행해 주세요.")
-        else:
-            job_labels = []
-            for j in jobs:
-                live_str = (
-                    j["live_start_time"][:16].replace("T", " ")
-                    if j.get("live_start_time")
-                    else "-"
-                )
-                job_labels.append(
-                    f"{j['title']}  |  라이브: {live_str}  |  {j['total_orders']}건"
-                )
-
-            search_idx = st.radio(
-                "검색할 추출 작업을 선택하세요 (최근 5건)",
-                options=range(len(jobs)),
-                format_func=lambda i: job_labels[i],
-                key="search_job_radio",
-            )
-            selected_job = jobs[search_idx]
-
-            keyword = st.text_input(
-                "검색 키워드 (대화 내용에서 정확히 포함된 파일을 찾습니다)",
-                key="search_keyword_input",
-                placeholder="예: 블랙, 환불, 입금",
-                on_change=lambda: st.session_state.update({"search_trigger": True}),
-            )
-
-            search_triggered = st.session_state.pop("search_trigger", False)
-            if st.button("🔍 검색", type="primary", key="search_run_btn") or search_triggered:
-                if not keyword.strip():
-                    st.warning("검색 키워드를 입력해 주세요.")
-                else:
-                    raw_files = get_raw_files_by_job(
-                        conn=db_conn, job_id=selected_job["id"]
-                    )
-                    if not raw_files:
-                        st.session_state["search_results"] = None
-                        st.info(
-                            "이 작업은 원본 대화가 저장되지 않았습니다. "
-                            "(채팅 검색 기능 적용 이전에 추출되었거나 DB 미연결 상태로 추출된 작업입니다.)"
-                        )
-                    else:
-                        live_date = None
-                        if selected_job.get("live_start_time"):
-                            live_date = selected_job["live_start_time"][:10]
-                        results = []
-                        for f in raw_files:
-                            matches = search_keyword_in_raw_csv(
-                                f.get("content", ""), keyword, live_date=live_date
-                            )
-                            if matches:
-                                results.append(
-                                    {
-                                        "id": f["id"],
-                                        "chat_name": f.get("chat_name") or "-",
-                                        "filename": f.get("filename"),
-                                        "content": f.get("content", ""),
-                                    }
-                                )
-                        st.session_state["search_results"] = {
-                            "keyword": keyword,
-                            "job_id": selected_job["id"],
-                            "items": results,
-                            "total": len(raw_files),
-                        }
-
-            # download_button 클릭으로 rerun돼도 결과가 유지되도록 session_state 사용
-            sr = st.session_state.get("search_results")
-            if sr and sr.get("job_id") == selected_job["id"]:
-                items = sr["items"]
-                st.caption(
-                    f"'{sr['keyword']}' 검색 결과: {len(items)}개 파일 매칭 "
-                    f"(전체 {sr['total']}개 중)"
-                )
-                if not items:
-                    st.info("매칭되는 파일이 없습니다.")
-                else:
-                    page_size = 20
-                    total_pages = max(1, (len(items) + page_size - 1) // page_size)
-                    if "search_page" not in st.session_state:
-                        st.session_state["search_page"] = 0
-                    # 새 검색 시 페이지 초기화
-                    if st.session_state.get("search_results_keyword") != sr["keyword"]:
-                        st.session_state["search_page"] = 0
-                        st.session_state["search_results_keyword"] = sr["keyword"]
-                    page = st.session_state["search_page"]
-
-                    start = page * page_size
-                    end = start + page_size
-                    page_items = items[start:end]
-
-                    header = st.columns([6, 1])
-                    header[0].markdown("**채팅명**")
-                    header[1].markdown("**다운로드**")
-                    for r in page_items:
-                        c1, c2 = st.columns([6, 1])
-                        c1.write(r["filename"])
-                        c2.download_button(
-                            label="📥",
-                            data=r["content"].encode("utf-8-sig"),
-                            file_name=r["filename"],
-                            mime="text/csv",
-                            key=f"search_dl_{r['id']}",
-                        )
-
-                    if total_pages > 1:
-                        st.caption(f"{page + 1} / {total_pages} 페이지")
-                        nav_cols = st.columns([1, 1, 8])
-                        if nav_cols[0].button("◀ 이전", key="search_prev", disabled=(page == 0)):
-                            st.session_state["search_page"] -= 1
-                            st.rerun()
-                        if nav_cols[1].button("다음 ▶", key="search_next", disabled=(page >= total_pages - 1)):
-                            st.session_state["search_page"] += 1
-                            st.rerun()
+if __name__ == "__main__":
+    main()

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,58 @@
+"""로그인 상태를 쿠키에 영속화하기 위한 서명 토큰 유틸리티.
+
+Streamlit의 ``session_state``는 웹소켓 세션에 종속되어 세션이 새로 만들어지면
+사라진다. 로그인 성공 시 서명 토큰을 쿠키에 저장하고, 세션이 리셋되면 쿠키의
+토큰을 검증해 로그인을 복원한다. 서명은 표준 라이브러리 ``hmac``만 사용한다.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+
+COOKIE_NAME = "c2o_auth"
+DEFAULT_TTL_SECONDS = 7 * 24 * 3600  # 7일
+
+
+def issue_token(user_id: str, secret: str, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> str:
+    """user_id와 만료시각을 담아 서명한 토큰을 발급한다."""
+    payload = {"sub": user_id, "exp": int(time.time()) + ttl_seconds}
+    payload_b64 = _b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    return f"{payload_b64}.{_sign(payload_b64, secret)}"
+
+
+def verify_token(token: str, secret: str) -> str | None:
+    """토큰의 서명과 만료를 검증하고, 유효하면 user_id를 반환한다."""
+    if not token or not secret:
+        return None
+    try:
+        payload_b64, signature = token.split(".", 1)
+    except ValueError:
+        return None
+    if not hmac.compare_digest(signature, _sign(payload_b64, secret)):
+        return None
+    try:
+        payload = json.loads(_b64decode(payload_b64))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if int(payload.get("exp", 0)) < int(time.time()):
+        return None
+    sub = payload.get("sub")
+    return sub if isinstance(sub, str) and sub else None
+
+
+def _sign(payload_b64: str, secret: str) -> str:
+    return hmac.new(
+        secret.encode("utf-8"), payload_b64.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(text: str) -> bytes:
+    padding = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(text + padding)

--- a/database.py
+++ b/database.py
@@ -5,6 +5,27 @@ from datetime import datetime
 from supabase import create_client, Client
 
 
+def _clean(value):
+    """pandas NaN을 JSON 직렬화 가능한 None으로 변환한다."""
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    return value
+
+
+def _rows_from(
+    items: list[dict], keys: tuple[str, ...], job_id: str
+) -> list[dict]:
+    created_at = datetime.now().isoformat()
+    return [
+        {
+            "job_id": job_id,
+            **{key: _clean(item.get(key)) for key in keys},
+            "created_at": created_at,
+        }
+        for item in items
+    ]
+
+
 def get_connection(url: str, key: str) -> Client:
     """Supabase 클라이언트를 생성하여 반환합니다."""
     return create_client(url, key)
@@ -60,32 +81,15 @@ def save_extracted_orders(
     확정한 건(exact/alias/typo/inferred)만 이 함수로 저장해야 합니다.
     unresolved 건은 save_unresolved_items()로 별도 저장합니다.
     """
-    def clean(value):
-        """pandas가 결측치를 float NaN으로 채운 경우 JSON 직렬화가 가능하도록 None으로 변환합니다."""
-        if isinstance(value, float) and math.isnan(value):
-            return None
-        return value
-
-    rows = [
-        {
-            "job_id": job_id,
-            "order_number": clean(o.get("order_number")),
-            "product": clean(o.get("product")),
-            "option": clean(o.get("option")),
-            "volume": clean(o.get("volume")),
-            "chat_name": clean(o.get("chat_name")),
-            "order_name": clean(o.get("order_name")),
-            "phone_number": clean(o.get("phone_number")),
-            "address": clean(o.get("address")),
-            "search_address": clean(o.get("search_address")),
-            "zip_code": clean(o.get("zip_code")),
-            "raw_product": clean(o.get("raw_product")),
-            "raw_option": clean(o.get("raw_option")),
-            "mapping_status": clean(o.get("mapping_status")),
-            "created_at": datetime.now().isoformat(),
-        }
-        for o in orders
-    ]
+    rows = _rows_from(
+        orders,
+        (
+            "order_number", "product", "option", "volume", "chat_name",
+            "order_name", "phone_number", "address", "search_address",
+            "zip_code", "raw_product", "raw_option", "mapping_status",
+        ),
+        job_id,
+    )
     conn.table("extracted_orders").insert(rows).execute()
 
 
@@ -103,27 +107,17 @@ def save_unresolved_items(
     if not items:
         return
 
-    def clean(value):
-        if isinstance(value, float) and math.isnan(value):
-            return None
-        return value
-
-    rows = [
-        {
-            "job_id": job_id,
-            "chat_name": clean(i.get("chat_name")),
-            "raw_product": clean(i.get("raw_product")),
-            "raw_option": clean(i.get("raw_option")),
-            "volume": clean(i.get("volume")),
-            "candidate_products": i.get("candidate_products") or [],
-            "mapping_reason": clean(i.get("mapping_reason")),
-            "order_name": clean(i.get("order_name")),
-            "phone_number": clean(i.get("phone_number")),
-            "address": clean(i.get("address")),
-            "created_at": datetime.now().isoformat(),
-        }
-        for i in items
-    ]
+    rows = _rows_from(
+        items,
+        (
+            "chat_name", "raw_product", "raw_option", "volume",
+            "candidate_products", "mapping_reason", "order_name",
+            "phone_number", "address",
+        ),
+        job_id,
+    )
+    for row in rows:
+        row["candidate_products"] = row.get("candidate_products") or []
     conn.table("unresolved_items").insert(rows).execute()
 
 
@@ -132,11 +126,15 @@ def save_training_record(
     job_id: str,
     user_id: str,
     chat_filename: str,
-    catalog_data: list,
+    catalog_data: dict[str, list[str]],
     chat_data: list,
     predicted_json: list | dict,
 ) -> str:
     """학습 데이터 레코드를 Supabase에 저장하고 id를 반환합니다."""
+    catalog_for_training = [
+        {"상품명": product, "옵션": options}
+        for product, options in catalog_data.items()
+    ]
     result = (
         conn.table("training_data")
         .insert(
@@ -144,7 +142,7 @@ def save_training_record(
                 "job_id": job_id,
                 "user_id": user_id,
                 "chat_filename": chat_filename,
-                "catalog_json": json.dumps(catalog_data, ensure_ascii=False),
+                "catalog_json": json.dumps(catalog_for_training, ensure_ascii=False),
                 "chat_json": json.dumps(chat_data, ensure_ascii=False),
                 "predicted_json": json.dumps(predicted_json, ensure_ascii=False),
                 "is_verified": False,

--- a/database.py
+++ b/database.py
@@ -194,6 +194,27 @@ def authenticate_user(conn: Client, user_id: str, password: str) -> dict | None:
     return None
 
 
+def get_account_by_user_id(conn: Client, user_id: str) -> dict | None:
+    """user_id로 활성 계정 정보를 조회합니다(비밀번호 검증 없이 세션 복원용).
+    서명 토큰으로 인증을 이미 확인한 뒤에만 호출해야 합니다.
+    반환 키: gemini_api_key, monthly_extract_limit (None이면 무제한).
+    부재하거나 비활성 계정이면 None을 반환합니다.
+    """
+    response = (
+        conn.table("accounts")
+        .select("gemini_api_key, is_active, monthly_extract_limit")
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if response.data and response.data[0].get("is_active"):
+        row = response.data[0]
+        return {
+            "gemini_api_key": row["gemini_api_key"],
+            "monthly_extract_limit": row.get("monthly_extract_limit"),
+        }
+    return None
+
+
 def save_extract_call_log(
     conn: Client,
     user_id: str,

--- a/excel_utils.py
+++ b/excel_utils.py
@@ -1,0 +1,39 @@
+import io
+
+import pandas as pd
+
+
+def write_excel_with_text_zipcode(
+    df: pd.DataFrame,
+    sheet_name: str,
+    zip_col: str = "우편번호",
+    extra_sheets: dict[str, pd.DataFrame] | None = None,
+) -> bytes:
+    """DataFrame을 Excel bytes로 만들고 우편번호 컬럼을 텍스트로 지정한다."""
+    output = io.BytesIO()
+    with pd.ExcelWriter(
+        output,
+        engine="openpyxl",
+        datetime_format="YYYY-MM-DD HH:MM:SS",
+    ) as writer:
+        df.to_excel(writer, index=False, sheet_name=sheet_name)
+        _set_text_column(writer.sheets[sheet_name], df, zip_col)
+
+        for extra_name, extra_df in (extra_sheets or {}).items():
+            extra_df.to_excel(writer, index=False, sheet_name=extra_name)
+            _set_text_column(writer.sheets[extra_name], extra_df, zip_col)
+
+    return output.getvalue()
+
+
+def _set_text_column(worksheet, df: pd.DataFrame, column: str) -> None:
+    if column not in df.columns:
+        return
+    column_index = df.columns.get_loc(column) + 1
+    for row in worksheet.iter_rows(
+        min_row=2,
+        max_row=worksheet.max_row,
+        min_col=column_index,
+        max_col=column_index,
+    ):
+        row[0].number_format = "@"

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ CLI 실행 예시:
 """
 
 import argparse
-import io
+import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -13,14 +13,15 @@ import yaml
 
 from services import (
     parse_custom_jsonl,
-    parse_csv,
-    extract_orders_from_chat,
+    parse_catalog_json,
+    normalize_catalog,
+    process_chat_file,
     lookup_zip_code,
     format_phone_number,
     normalize_zip_code,
-    extract_timestamp,
-    extract_chat_name,
 )
+from excel_utils import write_excel_with_text_zipcode
+from resolver import CatalogIndex
 from settings import get_env, load_prompt
 
 
@@ -63,98 +64,81 @@ def main():
     output_path = args.output or config["output"]["file_name"]
 
     print(f"[INFO] 카탈로그 파싱 중: {args.catalog}")
-    catalog_data = parse_custom_jsonl(FileWrapper(Path(args.catalog)))
+    catalog_wrapper = FileWrapper(Path(args.catalog))
+    if Path(args.catalog).suffix.lower() == ".json":
+        catalog_data = parse_catalog_json(catalog_wrapper)
+    else:
+        catalog_data = normalize_catalog(parse_custom_jsonl(catalog_wrapper))
+    catalog_index = CatalogIndex.build(catalog_data)
 
     all_extracted_orders = []
+    all_unresolved_rows = []
+    today_str = datetime.date.today().strftime("%Y%m%d")
+    sequence = 1
 
     for chat_path in args.chat:
         p = Path(chat_path)
         print(f"[INFO] 대화 파일 처리 중: {p.name}")
         wrapper = FileWrapper(p)
 
-        if p.suffix == ".csv":
-            chat_data, ts = parse_csv(
-                wrapper,
-                filename_prefix=config["csv"]["filename_prefix"],
-                exclude_messages=config["csv"]["exclude_messages"],
-            )
-        else:
-            chat_data = parse_custom_jsonl(wrapper)
-            ts = extract_timestamp(p.name)
-
         try:
-            extracted_data = extract_orders_from_chat(
-                args.api_key,
-                catalog_data,
-                chat_data,
-                model=config["gemini"]["model"],
-                temperature=config["gemini"]["temperature"],
+            result = process_chat_file(
+                chat_file=wrapper,
+                catalog=catalog_data,
+                index=catalog_index,
+                config=config,
+                api_key=args.api_key,
                 prompt_template=order_extraction_prompt,
+                order_number=f"{today_str}{sequence:03d}",
             )
         except RuntimeError as e:
             print(f"[ERROR] {e}")
             continue
 
-        if extracted_data:
-            items = extracted_data.get("items", [])
-            if items:
-                chat_name = extract_chat_name(
-                    p.name,
-                    filename_prefix=(
-                        config["csv"]["filename_prefix"] if p.suffix == ".csv" else ""
-                    ),
-                )
-                for item in items:
-                    row = {
-                        **item,
-                        "order_name": extracted_data.get("order_name"),
-                        "phone_number": extracted_data.get("phone_number"),
-                        "address": extracted_data.get("address"),
-                        "search_address": extracted_data.get("search_address"),
-                        "time": ts,
-                        "chat_name": chat_name,
-                    }
-                    all_extracted_orders.append(row)
-                print(f"[INFO] {len(items)}건 추출 완료")
+        all_extracted_orders.extend(result.orders)
+        all_unresolved_rows.extend(result.unresolved)
+        if result.extracted_data and result.extracted_data.get("items"):
+            sequence += 1
+        print(
+            f"[INFO] 확정 {len(result.orders)}건, "
+            f"검토 필요 {len(result.unresolved)}건"
+        )
 
-    if not all_extracted_orders:
+    if not all_extracted_orders and not all_unresolved_rows:
         print("[WARN] 추출된 주문 데이터가 없습니다.")
         return
 
     df = pd.DataFrame(all_extracted_orders, dtype=object)
-    df["phone_number"] = df["phone_number"].apply(format_phone_number)
+    if "phone_number" in df:
+        df["phone_number"] = df["phone_number"].apply(format_phone_number)
     if "zip_code" in df.columns:
         df["zip_code"] = df["zip_code"].apply(normalize_zip_code)
 
     juso_api_key = get_env("JUSO_API_KEY")
-    if juso_api_key:
+    if juso_api_key and "search_address" in df:
         print("[INFO] 우편번호 조회 중...")
         df["zip_code"] = df["search_address"].apply(
             lambda addr: lookup_zip_code(addr, juso_api_key)
         )
         df["zip_code"] = df["zip_code"].apply(normalize_zip_code)
 
-    df = df.reindex(columns=config["columns"])
+    col_map = config["output_columns"]
+    rename = {source: output for output, source in col_map.items() if source}
+    df = df.rename(columns=rename)
+    df = df.reindex(columns=list(col_map.keys()), fill_value="")
 
-    output = io.BytesIO()
-    with pd.ExcelWriter(
-        output, engine="openpyxl", datetime_format="YYYY-MM-DD HH:MM:SS"
-    ) as writer:
-        df.to_excel(writer, index=False, sheet_name=config["output"]["sheet_name"])
-        worksheet = writer.sheets[config["output"]["sheet_name"]]
-        for zip_col_name in ("우편번호", "zip_code"):
-            if zip_col_name in df.columns:
-                zip_col_idx = df.columns.get_loc(zip_col_name) + 1
-                for row in worksheet.iter_rows(
-                    min_row=2,
-                    max_row=worksheet.max_row,
-                    min_col=zip_col_idx,
-                    max_col=zip_col_idx,
-                ):
-                    row[0].number_format = "@"
-                break
-
-    Path(output_path).write_bytes(output.getvalue())
+    unresolved_df = pd.DataFrame(all_unresolved_rows, dtype=object)
+    if not unresolved_df.empty and "candidate_products" in unresolved_df:
+        unresolved_df["candidate_products"] = unresolved_df[
+            "candidate_products"
+        ].apply(lambda value: ", ".join(value) if isinstance(value, list) else value)
+    excel_bytes = write_excel_with_text_zipcode(
+        df,
+        config["output"]["sheet_name"],
+        zip_col="우편번호" if "우편번호" in df else "zip_code",
+        extra_sheets={"검토필요": unresolved_df} if not unresolved_df.empty else None,
+    )
+    Path(output_path).write_bytes(excel_bytes)
     print(f"[INFO] 완료: {output_path} ({len(df)}건)")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit==1.59.1
+extra-streamlit-components==0.1.81
 emoji==2.15.0
 numpy==2.4.6
 pandas==3.0.3

--- a/resolver.py
+++ b/resolver.py
@@ -62,17 +62,6 @@ def _levenshtein_leq_one(a: str, b: str) -> bool:
     return True
 
 
-def catalog_list_to_dict(catalog_data: list) -> dict[str, list[str]]:
-    """[{"상품명": ..., "옵션": [...]}] 형태를 {상품명: [옵션...]} dict로 변환한다."""
-    catalog: dict[str, list[str]] = {}
-    for entry in catalog_data:
-        product = entry.get("상품명")
-        options = entry.get("옵션") or []
-        if product:
-            catalog[product] = list(options)
-    return catalog
-
-
 @dataclass
 class CatalogIndex:
     catalog: dict[str, list[str]]

--- a/services.py
+++ b/services.py
@@ -4,6 +4,7 @@ import json
 import io
 import unicodedata
 import requests
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -12,7 +13,21 @@ from google import genai
 from google.genai import types
 
 from models import OrderExtractionResult, ResolvedProductItem
-from resolver import CatalogIndex, catalog_list_to_dict, resolve_catalog_item
+from resolver import CatalogIndex, resolve_catalog_item
+
+
+Catalog = dict[str, list[str]]
+
+
+@dataclass
+class ExtractionResult:
+    """파일 하나의 추출 결과. UI와 저장소 계층에 의존하지 않는다."""
+
+    orders: list[dict] = field(default_factory=list)
+    unresolved: list[dict] = field(default_factory=list)
+    raw_file: dict = field(default_factory=dict)
+    chat_data: list[dict] = field(default_factory=list)
+    extracted_data: dict | None = None
 
 
 def parse_custom_jsonl(
@@ -53,32 +68,28 @@ def parse_custom_jsonl(
 
 def extract_orders_from_chat(
     api_key: str,
-    catalog_data: list,
+    catalog_data: Catalog,
     chat_data: list,
     model: str,
     temperature: float,
     prompt_template: str,
 ) -> dict | None:
     """Gemini API를 호출하여 대화에서 주문 정보를 추출합니다."""
-    api_key = re.sub(r"[^\x20-\x7E]", "", api_key).strip()
-    client = genai.Client(api_key=api_key)
+    client = _gemini_client(api_key)
 
     prompt = prompt_template.format(
-        catalog=json.dumps(catalog_data, ensure_ascii=False, indent=2),
+        catalog=json.dumps(catalog_to_list(catalog_data), ensure_ascii=False, indent=2),
         chat=json.dumps(chat_data, ensure_ascii=False, indent=2),
     )
 
     try:
-        response = client.models.generate_content(
+        return _generate_json(
+            client=client,
             model=model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                response_mime_type="application/json",
-                response_schema=OrderExtractionResult,
-                temperature=temperature,
-            ),
+            prompt=prompt,
+            schema=OrderExtractionResult,
+            temperature=temperature,
         )
-        return json.loads(response.text)
     except Exception as e:
         import traceback
 
@@ -90,7 +101,7 @@ def extract_orders_from_chat(
 
 def resolve_extracted_items(
     items: list[dict],
-    catalog_data: list,
+    index: CatalogIndex,
 ) -> list[ResolvedProductItem]:
     """LLM이 추출한 items(raw_product/raw_option 포함)를 CatalogResolver로 확정한다.
 
@@ -98,8 +109,6 @@ def resolve_extracted_items(
     카탈로그와 대조한 결과만 저장 대상으로 사용한다. `[주문완료]` 유무와 무관하게
     항상 적용한다.
     """
-    catalog = catalog_list_to_dict(catalog_data)
-    index = CatalogIndex.build(catalog)
     return [
         resolve_catalog_item(
             raw_product=item.get("raw_product"),
@@ -109,6 +118,26 @@ def resolve_extracted_items(
         )
         for item in items
     ]
+
+
+def _gemini_client(api_key: str):
+    """API 키를 정제하고 Gemini 클라이언트를 생성한다."""
+    clean_key = re.sub(r"[^\x20-\x7E]", "", api_key).strip()
+    return genai.Client(api_key=clean_key)
+
+
+def _generate_json(client, model: str, prompt: str, schema, temperature: float):
+    """공통 JSON structured output 호출."""
+    response = client.models.generate_content(
+        model=model,
+        contents=prompt,
+        config=types.GenerateContentConfig(
+            response_mime_type="application/json",
+            response_schema=schema,
+            temperature=temperature,
+        ),
+    )
+    return json.loads(response.text)
 
 
 def lookup_zip_code(address: str | None, juso_api_key: str) -> str | None:
@@ -175,22 +204,18 @@ def extract_search_address(
     prompt_template: str,
 ) -> str | None:
     """Gemini로 단일 주소에서 우편번호 검색용 도로명주소를 추출합니다."""
-    api_key = re.sub(r"[^\x20-\x7E]", "", api_key).strip()
-    client = genai.Client(api_key=api_key)
+    client = _gemini_client(api_key)
 
     prompt = prompt_template.format(address=address)
 
     try:
-        response = client.models.generate_content(
+        result = _generate_json(
+            client=client,
             model=model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                response_mime_type="application/json",
-                response_schema=str | None,
-                temperature=temperature,
-            ),
+            prompt=prompt,
+            schema=str | None,
+            temperature=temperature,
         )
-        result = json.loads(response.text)
         return result if isinstance(result, str) and result.strip() else None
     except Exception:
         return None
@@ -315,21 +340,41 @@ def generate_catalog_from_csv(source) -> dict:
     return catalog
 
 
-def parse_catalog_json(source) -> list:
+def parse_catalog_json(source) -> Catalog:
     """
-    {상품명: [옵션...]} 형태의 JSON 카탈로그를 파싱하여
-    기존 JSONL 형식과 호환되는 list[dict] 형태로 반환합니다.
+    {상품명: [옵션...]} 형태의 JSON 카탈로그를 내부 표준 dict로 반환합니다.
     """
     if isinstance(source, (str, Path)):
         raw = Path(source).read_bytes()
     else:
         raw = source.getvalue()
 
-    catalog_dict = json.loads(raw.decode("utf-8"))
+    catalog = json.loads(raw.decode("utf-8"))
+    if not isinstance(catalog, dict):
+        raise ValueError("카탈로그는 {상품명: [옵션...]} 형태의 JSON 객체여야 합니다.")
+    return {str(product): list(options or []) for product, options in catalog.items()}
+
+
+def catalog_to_list(catalog: Catalog) -> list[dict]:
+    """LLM 프롬프트 등 레거시 외부 경계에서만 사용하는 직렬화 형식."""
     return [
         {"상품명": product, "옵션": options}
-        for product, options in catalog_dict.items()
+        for product, options in catalog.items()
     ]
+
+
+def normalize_catalog(catalog_data: Catalog | list[dict]) -> Catalog:
+    """dict 표준 형식과 기존 list 형식을 내부 표준 dict로 정규화한다."""
+    if isinstance(catalog_data, dict):
+        return {
+            str(product): list(options or [])
+            for product, options in catalog_data.items()
+        }
+    return {
+        entry["상품명"]: list(entry.get("옵션") or [])
+        for entry in catalog_data
+        if entry.get("상품명")
+    }
 
 
 def parse_csv(
@@ -380,6 +425,113 @@ def parse_csv(
         messages.append({"user": user, "message": message})
 
     return messages, timestamp
+
+
+def process_chat_file(
+    chat_file,
+    catalog: Catalog,
+    index: CatalogIndex,
+    config: dict,
+    api_key: str,
+    prompt_template: str,
+    *,
+    display_name: str | None = None,
+    time_after: datetime | None = None,
+    time_before: datetime | None = None,
+    order_number: str | None = None,
+) -> ExtractionResult:
+    """대화 파일 하나를 파싱하고 추출·resolve·row 조립까지 수행한다.
+
+    Streamlit 및 DB 호출을 포함하지 않는다. 호출자는 반환된 원본/추출 결과를
+    필요에 따라 저장하고 사용자에게 진행 상태를 표시한다.
+    """
+    filename = display_name or getattr(chat_file, "name", str(chat_file))
+    suffix = Path(filename).suffix.lower()
+    filename_prefix = config.get("csv", {}).get("filename_prefix", "")
+
+    if suffix == ".csv":
+        chat_data, timestamp = parse_csv(
+            chat_file,
+            filename_prefix=filename_prefix,
+            exclude_messages=config.get("csv", {}).get("exclude_messages", []),
+            time_after=time_after,
+            time_before=time_before,
+        )
+        if isinstance(chat_file, (str, Path)):
+            raw_bytes = Path(chat_file).read_bytes()
+        else:
+            raw_bytes = chat_file.getvalue()
+        raw_content = raw_bytes.decode("utf-8-sig", errors="replace")
+    else:
+        chat_data = parse_custom_jsonl(
+            chat_file, time_after=time_after, time_before=time_before
+        )
+        timestamp = extract_timestamp(filename)
+        raw_content = ""
+
+    chat_name = extract_chat_name(
+        filename,
+        filename_prefix=filename_prefix if suffix == ".csv" else "",
+    )
+    raw_file = {
+        "filename": filename,
+        "chat_name": chat_name,
+        "content": raw_content,
+        "message_count": len(chat_data),
+    }
+
+    extracted_data = extract_orders_from_chat(
+        api_key=api_key,
+        catalog_data=catalog,
+        chat_data=chat_data,
+        model=config["gemini"]["model"],
+        temperature=config["gemini"]["temperature"],
+        prompt_template=prompt_template,
+    )
+    result = ExtractionResult(
+        raw_file=raw_file,
+        chat_data=chat_data,
+        extracted_data=extracted_data,
+    )
+    if not extracted_data:
+        return result
+
+    common = {
+        "order_name": extracted_data.get("order_name"),
+        "phone_number": extracted_data.get("phone_number"),
+        "address": extracted_data.get("address"),
+    }
+    for resolved in resolve_extracted_items(extracted_data.get("items", []), index):
+        if resolved.mapping_status == "unresolved":
+            result.unresolved.append(
+                {
+                    "chat_name": chat_name,
+                    "raw_product": resolved.raw_product,
+                    "raw_option": resolved.raw_option,
+                    "volume": resolved.volume,
+                    "candidate_products": resolved.candidate_products,
+                    "mapping_reason": resolved.mapping_reason,
+                    **common,
+                }
+            )
+            continue
+        result.orders.append(
+            {
+                "product": resolved.product,
+                "option": resolved.option,
+                "volume": resolved.volume,
+                "raw_product": resolved.raw_product,
+                "raw_option": resolved.raw_option,
+                "mapping_status": resolved.mapping_status,
+                **common,
+                "search_address": extracted_data.get("search_address"),
+                "time": timestamp,
+                "chat_name": chat_name,
+                "live_time": time_after,
+                "order_number": order_number,
+            }
+        )
+    return result
 
 
 def search_keyword_in_raw_csv(

--- a/tests/test_catalog_format.py
+++ b/tests/test_catalog_format.py
@@ -1,0 +1,18 @@
+import json
+
+from services import catalog_to_list, normalize_catalog, parse_catalog_json
+
+
+def test_parse_catalog_json_uses_dict_as_internal_format(tmp_path):
+    path = tmp_path / "catalog.json"
+    path.write_text(json.dumps({"상품": ["옵션"]}), encoding="utf-8")
+
+    assert parse_catalog_json(path) == {"상품": ["옵션"]}
+
+
+def test_legacy_catalog_list_is_normalized_only_at_boundary():
+    legacy = [{"상품명": "상품", "옵션": ["옵션"]}]
+    catalog = normalize_catalog(legacy)
+
+    assert catalog == {"상품": ["옵션"]}
+    assert catalog_to_list(catalog) == legacy

--- a/tests/test_regression_issue61.py
+++ b/tests/test_regression_issue61.py
@@ -62,8 +62,8 @@ def test_nonexistent_product_option_combo_not_saved():
 
 def test_full_pipeline_via_resolve_extracted_items():
     """LLM이 [주문완료] 두 행을 raw_product/raw_option으로 추출했다고 가정하고,
-    services.resolve_extracted_items()가 CatalogIndex 생성부터 최종 확정까지
-    올바르게 연결하는지 확인한다."""
+    미리 생성된 CatalogIndex를 사용하는 services.resolve_extracted_items()가
+    최종 확정까지 올바르게 연결하는지 확인한다."""
     llm_items = [
         {
             "raw_product": "드래곤백",
@@ -81,7 +81,7 @@ def test_full_pipeline_via_resolve_extracted_items():
         },
     ]
 
-    resolved = resolve_extracted_items(llm_items, CATALOG_LIST)
+    resolved = resolve_extracted_items(llm_items, CatalogIndex.build(CATALOG))
 
     assert resolved[0].product == "드래곤백"
     assert resolved[0].option == "레드"

--- a/tests/test_services_pipeline.py
+++ b/tests/test_services_pipeline.py
@@ -1,0 +1,112 @@
+import io
+
+import openpyxl
+import pandas as pd
+
+import services
+from excel_utils import write_excel_with_text_zipcode
+from resolver import CatalogIndex
+
+
+CATALOG = {
+    "드래곤백": ["레드", "진브라운"],
+    "드래곤 트리플백": ["카멜"],
+}
+CONFIG = {
+    "csv": {"filename_prefix": "이지픽_", "exclude_messages": []},
+    "gemini": {"model": "test-model", "temperature": 0.1},
+}
+
+
+class UploadedFile:
+    name = "이지픽_고객.csv"
+
+    def __init__(self):
+        self.data = (
+            "DATE,USER,MESSAGE\n"
+            '2026-07-18 10:00:00,customer,"드래곤백 레드 1"\n'
+        ).encode("utf-8-sig")
+
+    def getvalue(self):
+        return self.data
+
+
+def test_process_chat_file_builds_resolved_and_unresolved_rows(monkeypatch):
+    monkeypatch.setattr(
+        services,
+        "extract_orders_from_chat",
+        lambda **kwargs: {
+            "order_name": "홍길동",
+            "phone_number": "01012345678",
+            "address": "서울시 중구",
+            "search_address": "서울 중구 세종대로 1",
+            "items": [
+                {
+                    "raw_product": "드래곤백",
+                    "raw_option": "레드",
+                    "product": "잘못된 힌트",
+                    "option": "카멜",
+                    "volume": 2,
+                },
+                {
+                    "raw_product": "드래곤 트리플백",
+                    "raw_option": "레드",
+                    "product": None,
+                    "option": None,
+                    "volume": 1,
+                },
+            ],
+        },
+    )
+    index = CatalogIndex.build(CATALOG)
+
+    result = services.process_chat_file(
+        UploadedFile(),
+        CATALOG,
+        index,
+        CONFIG,
+        "api-key",
+        "prompt",
+        order_number="20260718001",
+    )
+
+    assert len(result.orders) == 1
+    assert result.orders[0]["product"] == "드래곤백"
+    assert result.orders[0]["option"] == "레드"
+    assert result.orders[0]["order_number"] == "20260718001"
+    assert result.orders[0]["chat_name"] == "고객"
+    assert len(result.unresolved) == 1
+    assert result.unresolved[0]["raw_product"] == "드래곤 트리플백"
+    assert result.raw_file["message_count"] == 1
+    assert result.raw_file["filename"] == "이지픽_고객.csv"
+
+
+def test_process_chat_file_reuses_prebuilt_catalog_index(monkeypatch):
+    monkeypatch.setattr(
+        services,
+        "extract_orders_from_chat",
+        lambda **kwargs: {"items": [], "order_name": None, "phone_number": None,
+                          "address": None, "search_address": None},
+    )
+    index = CatalogIndex.build(CATALOG)
+
+    def fail_if_rebuilt(*args, **kwargs):
+        raise AssertionError("CatalogIndex.build must not run inside the file pipeline")
+
+    monkeypatch.setattr(CatalogIndex, "build", fail_if_rebuilt)
+    services.process_chat_file(
+        UploadedFile(), CATALOG, index, CONFIG, "api-key", "prompt"
+    )
+    services.process_chat_file(
+        UploadedFile(), CATALOG, index, CONFIG, "api-key", "prompt"
+    )
+
+
+def test_excel_zipcode_column_is_text_and_keeps_leading_zero():
+    frame = pd.DataFrame({"주소": ["서울"], "우편번호": ["01234"]})
+    excel = write_excel_with_text_zipcode(frame, "주문내역")
+    workbook = openpyxl.load_workbook(io.BytesIO(excel))
+    cell = workbook["주문내역"]["B2"]
+
+    assert cell.value == "01234"
+    assert cell.number_format == "@"

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Streamlit 탭 UI 모듈."""

--- a/ui/common.py
+++ b/ui/common.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+import streamlit as st
+
+from database import get_jobs_by_user
+
+
+@dataclass(frozen=True)
+class AppContext:
+    db_conn: object | None
+    config: dict
+    api_key: str
+    user_id: str
+    juso_api_key: str
+    order_extraction_prompt: str
+    address_to_search_prompt: str
+
+
+def select_job_ui(
+    db_conn,
+    user_id: str,
+    label: str,
+    *,
+    key: str,
+) -> dict | None:
+    """최근 작업 목록과 공통 라벨 형식의 radio 선택 UI를 표시한다."""
+    jobs = get_jobs_by_user(conn=db_conn, user_id=user_id)
+    if not jobs:
+        return None
+    labels = [_job_label(job) for job in jobs]
+    selected = st.radio(
+        label,
+        options=range(len(jobs)),
+        format_func=lambda index: labels[index],
+        key=key,
+    )
+    return jobs[selected]
+
+
+def _job_label(job: dict) -> str:
+    live_start = job.get("live_start_time")
+    live_text = live_start[:16].replace("T", " ") if live_start else "-"
+    return (
+        f"{job['title']}  |  라이브: {live_text}  |  "
+        f"{job.get('total_orders', 0)}건"
+    )

--- a/ui/tab_catalog.py
+++ b/ui/tab_catalog.py
@@ -1,0 +1,64 @@
+import datetime
+import json
+
+import pandas as pd
+import streamlit as st
+
+from services import generate_catalog_from_csv
+from ui.common import AppContext
+
+
+def render(ctx: AppContext) -> None:
+    st.markdown(
+        '<span class="step-badge">1</span> **재고 CSV 업로드**',
+        unsafe_allow_html=True,
+    )
+    source = st.file_uploader(
+        "CSV 파일을 업로드하세요. (상품명·옵션내용 컬럼 필요)",
+        type=["csv"],
+        key="catalog_csv_uploader",
+    )
+    if not source:
+        return
+
+    try:
+        catalog = generate_catalog_from_csv(source)
+    except ValueError as exc:
+        st.error(str(exc))
+        return
+
+    st.markdown(
+        '<span class="step-badge">2</span> **미리보기 및 확인**',
+        unsafe_allow_html=True,
+    )
+    columns = st.columns(3)
+    columns[0].metric("총 상품 수", len(catalog))
+    columns[1].metric("총 옵션 수", sum(len(options) for options in catalog.values()))
+    columns[2].metric(
+        "단일상품", sum(options == ["단일상품"] for options in catalog.values())
+    )
+
+    preview = pd.DataFrame(
+        [
+            {"상품명": product, "옵션": ", ".join(options), "옵션 수": len(options)}
+            for product, options in catalog.items()
+        ],
+        dtype=object,
+    )
+    preview.index = preview.index + 1
+    preview.index.name = "#"
+    st.dataframe(preview, width="stretch")
+
+    st.markdown(
+        '<span class="step-badge">3</span> **카탈로그 다운로드**',
+        unsafe_allow_html=True,
+    )
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    st.download_button(
+        label="📥 catalog.json 다운로드",
+        data=json.dumps(catalog, ensure_ascii=False, indent=2).encode("utf-8"),
+        file_name=f"catalog_{timestamp}.json",
+        mime="application/json",
+        type="primary",
+        width="stretch",
+    )

--- a/ui/tab_history.py
+++ b/ui/tab_history.py
@@ -1,0 +1,76 @@
+import json
+
+import pandas as pd
+import streamlit as st
+
+from database import get_catalog_by_job, get_orders_by_job
+from excel_utils import write_excel_with_text_zipcode
+from services import normalize_catalog, normalize_zip_code
+from ui.common import AppContext, select_job_ui
+
+
+def render(ctx: AppContext) -> None:
+    if not ctx.db_conn:
+        st.warning("DB 연결이 설정되지 않아 이력을 불러올 수 없습니다.")
+        return
+
+    job = select_job_ui(
+        ctx.db_conn,
+        ctx.user_id,
+        "다운로드할 이력을 선택하세요 (최근 5건)",
+        key="history_job_radio",
+    )
+    if not job:
+        st.info("저장된 추출 이력이 없습니다.")
+        return
+
+    orders = get_orders_by_job(conn=ctx.db_conn, job_id=job["id"])
+    if not orders:
+        st.info("해당 이력에 저장된 주문 데이터가 없습니다.")
+        return
+
+    frame = pd.DataFrame(orders, dtype=object)
+    frame = frame.drop(
+        columns=[c for c in ("id", "job_id", "created_at") if c in frame.columns]
+    )
+    col_map = ctx.config["output_columns"]
+    frame = frame.rename(columns={value: key for key, value in col_map.items() if value})
+    frame = frame.reindex(columns=list(col_map.keys()), fill_value="")
+    if "우편번호" in frame:
+        frame["우편번호"] = frame["우편번호"].apply(normalize_zip_code)
+
+    st.dataframe(frame.head(20), width="stretch")
+    st.caption(f"총 {len(frame)}건 (최대 20건 미리보기)")
+    downloads = st.columns(2)
+    with downloads[0]:
+        st.download_button(
+            label="📥 엑셀 파일(.xlsx) 다운로드",
+            data=write_excel_with_text_zipcode(
+                frame, ctx.config["output"]["sheet_name"]
+            ),
+            file_name=f"{job['title']}.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            type="primary",
+            key="hist_download_btn",
+            width="stretch",
+        )
+    with downloads[1]:
+        stored = get_catalog_by_job(conn=ctx.db_conn, job_id=job["id"])
+        if stored:
+            catalog = normalize_catalog(json.loads(stored))
+            st.download_button(
+                label="📋 카탈로그(.json) 다운로드",
+                data=json.dumps(catalog, ensure_ascii=False, indent=2).encode("utf-8"),
+                file_name=f"catalog_{job['title']}.json",
+                mime="application/json",
+                type="secondary",
+                key="hist_catalog_btn",
+                width="stretch",
+            )
+        else:
+            st.button(
+                "📋 카탈로그 정보 없음",
+                disabled=True,
+                key="hist_catalog_btn_disabled",
+                width="stretch",
+            )

--- a/ui/tab_order.py
+++ b/ui/tab_order.py
@@ -1,0 +1,313 @@
+import datetime
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from database import (
+    create_extraction_job,
+    get_monthly_api_call_count,
+    save_extract_call_log,
+    save_extracted_orders,
+    save_raw_chat_files,
+    save_training_record,
+    save_unresolved_items,
+    update_extraction_job_total,
+)
+from excel_utils import write_excel_with_text_zipcode
+from resolver import CatalogIndex
+from services import (
+    format_phone_number,
+    lookup_zip_code,
+    normalize_zip_code,
+    parse_catalog_json,
+    process_chat_file,
+)
+from ui.common import AppContext
+
+
+MAPPING_STATUS_LABELS = {
+    "exact": "✅ 확정",
+    "alias": "✅ 확정",
+    "typo": "🔧 자동보정",
+    "inferred": "🔧 자동보정",
+}
+
+
+def render(ctx: AppContext) -> None:
+    catalog_file, chat_files = _render_uploaders()
+    time_after, time_before = _render_live_time()
+    if not st.button("🚀 주문서 추출 실행", type="primary", width="stretch"):
+        return
+    if not _validate_inputs(ctx, catalog_file, chat_files):
+        return
+
+    files_to_process = _apply_monthly_limit(ctx, chat_files)
+    if not files_to_process:
+        return
+    _run_extraction(
+        ctx, catalog_file, files_to_process, time_after, time_before
+    )
+
+
+def _render_uploaders():
+    columns = st.columns(2)
+    with columns[0]:
+        st.markdown(
+            '<span class="step-badge">1</span> **카탈로그 업로드**',
+            unsafe_allow_html=True,
+        )
+        catalog_file = st.file_uploader("카탈로그를 업로드하세요.", type=["json"])
+    with columns[1]:
+        st.markdown(
+            '<span class="step-badge">2</span> **대화 내역 업로드**',
+            unsafe_allow_html=True,
+        )
+        uploader_key = st.session_state.setdefault("chat_uploader_key", 0)
+        files = st.file_uploader(
+            "카카오톡 대화 파일들을 업로드하세요.",
+            type=["csv"],
+            accept_multiple_files=True,
+            key=f"chat_uploader_{uploader_key}",
+        )
+        files, display_names = _dedupe_uploaded_files(files or [])
+        if files:
+            st.session_state["chat_display_names"] = display_names
+            with st.expander(f"📁 업로드된 파일 {len(files)}개 보기"):
+                for uploaded in files:
+                    st.write(f"• {display_names.get(id(uploaded), uploaded.name)}")
+            if st.button("❌ 업로드 파일 전체 삭제", key="clear_chat_files"):
+                st.session_state["chat_uploader_key"] += 1
+                st.rerun()
+    return catalog_file, files
+
+
+def _dedupe_uploaded_files(files: list) -> tuple[list, dict[int, str]]:
+    groups: dict[str, list[tuple[bytes, object]]] = {}
+    for uploaded in files:
+        content = uploaded.getvalue()
+        entries = groups.setdefault(uploaded.name, [])
+        if not any(content == existing for existing, _ in entries):
+            entries.append((content, uploaded))
+
+    unique = []
+    display_names = {}
+    for name, entries in groups.items():
+        for index, (_, uploaded) in enumerate(entries, start=1):
+            display_name = name
+            if len(entries) > 1:
+                path = Path(name)
+                display_name = f"{path.stem}({index}){path.suffix}"
+            unique.append(uploaded)
+            display_names[id(uploaded)] = display_name
+    return unique, display_names
+
+
+def _render_live_time() -> tuple[datetime.datetime, datetime.datetime]:
+    st.markdown(
+        '<span class="step-badge">3</span> **라이브쇼핑 시간 입력**',
+        unsafe_allow_html=True,
+    )
+    columns = st.columns(4)
+    start_date = columns[0].date_input("시작 날짜")
+    start_time = columns[1].time_input("시작 시간")
+    end_date = columns[2].date_input("종료 날짜", value=start_date)
+    end_time = columns[3].time_input("종료 시간", value=datetime.time(23, 59))
+    return (
+        datetime.datetime.combine(start_date, start_time),
+        datetime.datetime.combine(end_date, end_time),
+    )
+
+
+def _validate_inputs(ctx, catalog_file, chat_files) -> bool:
+    if not ctx.api_key:
+        st.warning("API Key가 할당되지 않았습니다. 관리자에게 문의하세요.")
+    elif not catalog_file:
+        st.warning("카탈로그 파일을 업로드해 주세요.")
+    elif not chat_files:
+        st.warning("대화 내역 파일을 1개 이상 업로드해 주세요.")
+    else:
+        return True
+    return False
+
+
+def _apply_monthly_limit(ctx: AppContext, files: list) -> list:
+    limit = st.session_state.get("monthly_extract_limit")
+    if not ctx.db_conn or limit is None:
+        return files
+    used = get_monthly_api_call_count(ctx.db_conn, ctx.user_id)
+    remaining = limit - used
+    if remaining <= 0:
+        st.error(
+            f"이번 달 API 호출 한도({limit}회)를 모두 사용했습니다. "
+            "다음 달 1일에 초기화됩니다."
+        )
+        return []
+    if len(files) > remaining:
+        st.warning(
+            f"이번 달 남은 한도가 {remaining}회입니다. "
+            f"파일 {len(files)}개 중 {remaining}개만 처리합니다."
+        )
+        return files[:remaining]
+    return files
+
+
+def _run_extraction(ctx, catalog_file, files, time_after, time_before) -> None:
+    with st.status("주문서 추출 중입니다", expanded=True) as status:
+        st.write("📋 카탈로그를 파싱 중")
+        catalog = parse_catalog_json(catalog_file)
+        index = CatalogIndex.build(catalog)
+        orders, unresolved, raw_files = [], [], []
+        job_id = _create_job(ctx, time_after)
+
+        date_prefix = datetime.date.today().strftime("%Y%m%d")
+        sequence = 1
+        progress_text = st.empty()
+        progress_bar = st.progress(0)
+        display_names = st.session_state.get("chat_display_names", {})
+
+        for position, chat_file in enumerate(files):
+            filename = display_names.get(id(chat_file), chat_file.name)
+            progress_text.write(f"💬 채팅 내역 분석 중 ({position}/{len(files)})")
+            try:
+                result = process_chat_file(
+                    chat_file=chat_file,
+                    catalog=catalog,
+                    index=index,
+                    config=ctx.config,
+                    api_key=ctx.api_key,
+                    prompt_template=ctx.order_extraction_prompt,
+                    display_name=filename,
+                    time_after=time_after,
+                    time_before=time_before,
+                    order_number=f"{date_prefix}{sequence:03d}",
+                )
+            except RuntimeError as exc:
+                st.error(str(exc))
+                _update_progress(progress_bar, progress_text, position, len(files))
+                continue
+
+            orders.extend(result.orders)
+            unresolved.extend(result.unresolved)
+            raw_files.append(result.raw_file)
+            if result.extracted_data and result.extracted_data.get("items"):
+                sequence += 1
+            _save_file_result(ctx, job_id, filename, catalog, result)
+            _update_progress(progress_bar, progress_text, position, len(files))
+
+        _save_batch_result(ctx, job_id, raw_files, unresolved)
+        status.update(label="🎉 주문 데이터 추출이 완료되었습니다!", state="complete")
+
+    _render_result(ctx, job_id, orders, unresolved)
+
+
+def _update_progress(bar, text, position: int, total: int) -> None:
+    completed = position + 1
+    bar.progress(completed / total)
+    text.write(f"💬 채팅 내역 분석 중 ({completed}/{total})")
+
+
+def _create_job(ctx: AppContext, live_start: datetime.datetime):
+    if not ctx.db_conn:
+        return None
+    return create_extraction_job(
+        conn=ctx.db_conn,
+        user_id=ctx.user_id,
+        title=datetime.datetime.now().strftime("%Y%m%d_%H%M%S"),
+        live_start_time=live_start,
+        model=ctx.config["gemini"]["model"],
+    )
+
+
+def _save_file_result(ctx, job_id, filename, catalog, result) -> None:
+    if not ctx.db_conn or not job_id:
+        return
+    save_extract_call_log(ctx.db_conn, ctx.user_id, job_id, filename)
+    if result.extracted_data:
+        save_training_record(
+            conn=ctx.db_conn,
+            job_id=job_id,
+            user_id=ctx.user_id,
+            chat_filename=filename,
+            catalog_data=catalog,
+            chat_data=result.chat_data,
+            predicted_json=result.extracted_data,
+        )
+
+
+def _save_batch_result(ctx, job_id, raw_files, unresolved) -> None:
+    if not ctx.db_conn or not job_id:
+        return
+    save_raw_chat_files(ctx.db_conn, job_id, ctx.user_id, raw_files)
+    save_unresolved_items(ctx.db_conn, job_id, unresolved)
+
+
+def _render_result(ctx, job_id, orders, unresolved) -> None:
+    unresolved_df = pd.DataFrame(unresolved, dtype=object)
+    if not unresolved_df.empty and "candidate_products" in unresolved_df:
+        unresolved_df["candidate_products"] = unresolved_df[
+            "candidate_products"
+        ].apply(lambda value: ", ".join(value) if isinstance(value, list) else (value or ""))
+
+    if orders:
+        frame = pd.DataFrame(orders, dtype=object)
+        frame["phone_number"] = frame["phone_number"].apply(format_phone_number)
+        if ctx.juso_api_key:
+            frame["zip_code"] = frame["search_address"].apply(
+                lambda address: lookup_zip_code(address, ctx.juso_api_key)
+            )
+            frame["zip_code"] = frame["zip_code"].apply(normalize_zip_code)
+        _save_orders(ctx, job_id, frame)
+        _render_orders_and_download(ctx, frame, unresolved_df)
+    elif unresolved_df.empty:
+        st.error("추출된 데이터가 없습니다. 원본 데이터나 API 상태를 확인해 주세요.")
+
+    if not unresolved_df.empty:
+        st.warning(
+            f"⚠️ {len(unresolved_df)}건은 자동 매핑에 실패하여 검토가 필요합니다. "
+            "임의로 확정하지 않았으니 아래 내역을 확인해 주세요."
+        )
+        st.dataframe(
+            unresolved_df[
+                ["chat_name", "raw_product", "raw_option", "volume", "candidate_products", "mapping_reason"]
+            ],
+            width="stretch",
+        )
+
+
+def _save_orders(ctx, job_id, frame) -> None:
+    if not ctx.db_conn or not job_id:
+        return
+    save_extracted_orders(ctx.db_conn, job_id, frame.to_dict("records"))
+    update_extraction_job_total(ctx.db_conn, job_id, len(frame))
+
+
+def _render_orders_and_download(ctx, frame, unresolved_df) -> None:
+    col_map = ctx.config["output_columns"]
+    rename = {value: key for key, value in col_map.items() if value}
+
+    display = frame.copy()
+    display["매핑"] = display["mapping_status"].map(MAPPING_STATUS_LABELS).fillna("✅ 확정")
+    display["원문"] = display.apply(
+        lambda row: (
+            f"{row.get('raw_product') or ''} {row.get('raw_option') or ''}".strip()
+            if row.get("mapping_status") in ("typo", "inferred") else ""
+        ),
+        axis=1,
+    )
+    display = display.rename(columns=rename).reindex(
+        columns=list(col_map.keys()) + ["매핑", "원문"], fill_value=""
+    )
+    st.dataframe(display, width="stretch")
+
+    output = frame.rename(columns=rename).reindex(columns=list(col_map.keys()), fill_value="")
+    extras = {"검토필요": unresolved_df} if not unresolved_df.empty else None
+    st.download_button(
+        label="📥 엑셀 파일(.xlsx) 다운로드",
+        data=write_excel_with_text_zipcode(
+            output, ctx.config["output"]["sheet_name"], extra_sheets=extras
+        ),
+        file_name=ctx.config["output"]["file_name"],
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        type="primary",
+    )

--- a/ui/tab_search.py
+++ b/ui/tab_search.py
@@ -1,0 +1,115 @@
+import streamlit as st
+
+from database import get_raw_files_by_job
+from services import search_keyword_in_raw_csv
+from ui.common import AppContext, select_job_ui
+
+
+def render(ctx: AppContext) -> None:
+    if not ctx.db_conn:
+        st.warning("DB 연결이 설정되지 않아 검색할 수 없습니다.")
+        return
+
+    job = select_job_ui(
+        ctx.db_conn,
+        ctx.user_id,
+        "검색할 추출 작업을 선택하세요 (최근 5건)",
+        key="search_job_radio",
+    )
+    if not job:
+        st.info("저장된 추출 이력이 없습니다. 먼저 주문서 추출을 실행해 주세요.")
+        return
+
+    keyword = st.text_input(
+        "검색 키워드 (대화 내용에서 정확히 포함된 파일을 찾습니다)",
+        key="search_keyword_input",
+        placeholder="예: 블랙, 환불, 입금",
+        on_change=lambda: st.session_state.update({"search_trigger": True}),
+    )
+    triggered = st.session_state.pop("search_trigger", False)
+    if st.button("🔍 검색", type="primary", key="search_run_btn") or triggered:
+        _search(ctx, job, keyword)
+
+    result = st.session_state.get("search_results")
+    if not result or result.get("job_id") != job["id"]:
+        return
+    _render_results(result)
+
+
+def _search(ctx: AppContext, job: dict, keyword: str) -> None:
+    if not keyword.strip():
+        st.warning("검색 키워드를 입력해 주세요.")
+        return
+    raw_files = get_raw_files_by_job(conn=ctx.db_conn, job_id=job["id"])
+    if not raw_files:
+        st.session_state["search_results"] = None
+        st.info(
+            "이 작업은 원본 대화가 저장되지 않았습니다. "
+            "(채팅 검색 기능 적용 이전이거나 DB 미연결 상태로 추출된 작업입니다.)"
+        )
+        return
+
+    live_date = job.get("live_start_time", "")[:10] or None
+    items = []
+    for raw_file in raw_files:
+        if search_keyword_in_raw_csv(
+            raw_file.get("content", ""), keyword, live_date=live_date
+        ):
+            items.append(
+                {
+                    "id": raw_file["id"],
+                    "filename": raw_file.get("filename"),
+                    "content": raw_file.get("content", ""),
+                }
+            )
+    st.session_state["search_results"] = {
+        "keyword": keyword,
+        "job_id": job["id"],
+        "items": items,
+        "total": len(raw_files),
+    }
+
+
+def _render_results(result: dict) -> None:
+    items = result["items"]
+    st.caption(
+        f"'{result['keyword']}' 검색 결과: {len(items)}개 파일 매칭 "
+        f"(전체 {result['total']}개 중)"
+    )
+    if not items:
+        st.info("매칭되는 파일이 없습니다.")
+        return
+
+    page_size = 20
+    total_pages = max(1, (len(items) + page_size - 1) // page_size)
+    if st.session_state.get("search_results_keyword") != result["keyword"]:
+        st.session_state["search_page"] = 0
+        st.session_state["search_results_keyword"] = result["keyword"]
+    page = min(st.session_state.get("search_page", 0), total_pages - 1)
+
+    header = st.columns([6, 1])
+    header[0].markdown("**채팅명**")
+    header[1].markdown("**다운로드**")
+    for item in items[page * page_size : (page + 1) * page_size]:
+        columns = st.columns([6, 1])
+        columns[0].write(item["filename"])
+        columns[1].download_button(
+            label="📥",
+            data=item["content"].encode("utf-8-sig"),
+            file_name=item["filename"],
+            mime="text/csv",
+            key=f"search_dl_{item['id']}",
+        )
+
+    if total_pages <= 1:
+        return
+    st.caption(f"{page + 1} / {total_pages} 페이지")
+    navigation = st.columns([1, 1, 8])
+    if navigation[0].button("◀ 이전", key="search_prev", disabled=page == 0):
+        st.session_state["search_page"] = page - 1
+        st.rerun()
+    if navigation[1].button(
+        "다음 ▶", key="search_next", disabled=page >= total_pages - 1
+    ):
+        st.session_state["search_page"] = page + 1
+        st.rerun()

--- a/ui/tab_zipcode.py
+++ b/ui/tab_zipcode.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from excel_utils import write_excel_with_text_zipcode
+from services import batch_lookup_zip_codes
+from ui.common import AppContext
+
+
+def render(ctx: AppContext) -> None:
+    st.markdown(
+        '<span class="step-badge">1</span> **엑셀 파일 업로드**',
+        unsafe_allow_html=True,
+    )
+    source = st.file_uploader(
+        "주소 컬럼이 포함된 엑셀 파일을 업로드하세요.",
+        type=["xlsx", "xls"],
+        key="zip_excel_uploader",
+    )
+    if not source:
+        return
+
+    frame = pd.read_excel(source)
+    if "주소" not in frame.columns:
+        st.error(f"'주소' 컬럼을 찾을 수 없습니다. 발견된 컬럼: {list(frame.columns)}")
+        return
+
+    st.markdown(
+        '<span class="step-badge">2</span> **미리보기**',
+        unsafe_allow_html=True,
+    )
+    has_zip = "우편번호" in frame.columns
+    if has_zip:
+        st.info("파일에 이미 '우편번호' 컬럼이 있습니다. 조회 결과로 덮어씁니다.")
+    st.dataframe(frame.head(10), width="stretch")
+    st.caption(f"총 {len(frame)}건")
+
+    if not st.button(
+        "📮 우편번호 조회 실행", type="primary", width="stretch", key="zip_lookup_btn"
+    ):
+        return
+    if not ctx.api_key:
+        st.warning("API Key가 할당되지 않았습니다. 관리자에게 문의하세요.")
+        return
+    if not ctx.juso_api_key:
+        st.warning("도로명주소 API 키가 설정되지 않았습니다.")
+        return
+
+    with st.status("우편번호 조회 중입니다", expanded=True) as status:
+        progress_text = st.empty()
+        progress_bar = st.progress(0)
+
+        def progress(index, total):
+            if total:
+                progress_bar.progress(min((index + 1) / total, 1.0))
+            progress_text.write(f"📮 우편번호 조회 중... ({index + 1}/{total})")
+
+        result = batch_lookup_zip_codes(
+            df=frame,
+            address_col="주소",
+            juso_api_key=ctx.juso_api_key,
+            api_key=ctx.api_key,
+            model=ctx.config["gemini"]["model"],
+            temperature=ctx.config["gemini"]["temperature"],
+            prompt_template=ctx.address_to_search_prompt,
+            progress_callback=progress,
+        )
+        if has_zip:
+            frame["우편번호"] = result
+        else:
+            frame.insert(frame.columns.get_loc("주소") + 1, "우편번호", result)
+        found = int((frame["우편번호"] != "").sum())
+        status.update(
+            label=f"🎉 우편번호 조회 완료! ({found}/{len(frame)}건 성공)",
+            state="complete",
+        )
+
+    st.markdown(
+        '<span class="step-badge">3</span> **결과 확인 및 다운로드**',
+        unsafe_allow_html=True,
+    )
+    metrics = st.columns(3)
+    metrics[0].metric("전체", len(frame))
+    metrics[1].metric("성공", found)
+    metrics[2].metric("미조회", len(frame) - found)
+    st.dataframe(frame, width="stretch")
+    st.download_button(
+        label="📥 엑셀 파일(.xlsx) 다운로드",
+        data=write_excel_with_text_zipcode(frame, "Sheet1"),
+        file_name=f"{Path(source.name).stem}_우편번호.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        type="primary",
+        key="zip_download_btn",
+    )


### PR DESCRIPTION
# 주문 추출 파이프라인 및 Streamlit UI 구조 리팩토링

> ⚠️ **배포 주의**: 이 PR에는 로그인 쿠키 영속화(#69)가 포함되어 있습니다. 배포 전
> Railway 서비스 **Variables**에 `AUTH_SECRET`(길고 무작위한 문자열)을 등록해야
> 로그인 유지 기능이 활성화됩니다. 미설정 시 기존처럼 세션 전용으로 안전하게 폴백합니다.

## 요약

주문 추출의 핵심 비즈니스 로직을 Streamlit UI에서 분리하고, 웹 앱과 CLI가 동일한 카탈로그 검증 파이프라인을 사용하도록 통일했습니다.

또한 970줄 규모의 단일 `app.py`를 탭별 모듈로 분리하고, Excel 생성·DB row 조립·Gemini 클라이언트 생성 등의 중복 코드를 공통화했습니다. Streamlit rerun마다 반복되던 DB 클라이언트 및 정적 리소스 초기화에는 캐싱을 적용했습니다.

추가로, 추출 도중 로그인 화면으로 튕기던 세션 초기화 버그(#69)를 로그인 쿠키 영속화로 수정했습니다.

## 주요 변경 사항

### 주문 추출 파이프라인 분리

- 파일 1개에 대한 파싱 → Gemini 추출 → resolver 매핑 → row 조립을 `process_chat_file()`로 분리했습니다.
- 확정 주문, 검토 필요 항목, 검색용 원본 파일 정보를 `ExtractionResult`로 반환합니다.
- 파이프라인은 Streamlit과 DB에 의존하지 않아 독립적으로 테스트할 수 있습니다.
- 주문번호 채번, 원본 필드 보존, unresolved 분기 규칙을 서비스 계층으로 이동했습니다.

### 웹 앱과 CLI 동작 통일

- `app.py`와 `main.py`가 모두 `process_chat_file()`을 사용합니다.
- CLI에서도 LLM이 반환한 상품/옵션을 직접 저장하지 않고 항상 `CatalogResolver`로 재검증합니다.
- CLI 출력에도 검토 필요 항목을 별도 시트로 포함합니다.

### 카탈로그 처리 및 성능 개선

- 내부 카탈로그 표준 형식을 `{상품명: [옵션...]}` dict로 통일했습니다.
- LLM 프롬프트와 training data 저장 경계에서만 기존 list 형식으로 직렬화합니다.
- `catalog_list_to_dict()`와 불필요한 dict ↔ list 왕복 변환을 제거했습니다.
- 동일한 카탈로그의 `CatalogIndex`를 파일별로 다시 만들지 않고 처리 시작 시 한 번만 생성해 재사용합니다.

### 로그인 상태 쿠키 영속화 (#69)

- 추출 도중 Railway 엣지 프록시가 유휴 웹소켓을 끊으면 Streamlit이 새 세션을 생성하며 `session_state`가 초기화되어 로그인 화면으로 튕기던 문제를 수정했습니다.
- 로그인 성공 시 `{이메일 + 만료시각}`을 `AUTH_SECRET`으로 HMAC 서명한 토큰을 쿠키에 저장하고, 세션이 비면 쿠키의 토큰을 검증해 로그인을 복원합니다.
- 서명 로직은 표준 라이브러리 `hmac`만 사용하며(`auth.py`), 토큰 검증 후 `get_account_by_user_id()`로 현재 계정 상태를 다시 읽어 비활성 계정 복원을 차단합니다.
- 쿠키 입출력에 `extra-streamlit-components`(CookieManager)를 추가했습니다.
- `AUTH_SECRET` 환경변수를 추가했습니다(미설정 시 세션 전용 폴백).

### 공통 로직 추출

- Excel 생성 및 우편번호 텍스트 서식을 `write_excel_with_text_zipcode()`로 통합했습니다.
- 주문 추출, 추출 이력, 우편번호 기능의 Excel 생성 코드가 동일한 헬퍼를 사용합니다.
- `database.py`의 NaN 정제 및 DB row 생성 로직을 공통화했습니다.
- Gemini API 키 정제, 클라이언트 생성, JSON structured output 호출을 공통화했습니다.
- 추출 이력/채팅 검색 탭의 작업 목록 라벨과 선택 UI를 공통화했습니다.

### Streamlit UI 모듈화 및 캐싱

- `app.py`를 로그인, 사이드바, 공통 컨텍스트 구성, 탭 등록 중심의 진입점으로 축소했습니다.
- 아래 5개 탭을 `ui/` 모듈로 분리했습니다.
  - 주문서 추출
  - 카탈로그 생성
  - 우편번호 추출
  - 나의 추출 이력
  - 채팅 검색
- Supabase 클라이언트에는 `st.cache_resource`를 적용했습니다.
- config, CSS, 프롬프트에는 `st.cache_data`를 적용했습니다.
- 월간 API 사용량에는 60초 TTL 캐시를 적용했습니다.

## 테스트

- `pytest -q`: **27 passed**
- 전체 변경 Python 파일 `py_compile` 통과
- Streamlit 로그인 화면 smoke test 통과
- `git diff --check` 통과
- 로그인 서명 토큰(`auth.py`) 검증: 정상/위조/만료/키 불일치/빈 값 처리 확인

추가된 테스트 범위:

- 정상 resolve 및 unresolved row 조립
- 주문번호와 채팅 원본 정보 조립
- 여러 파일 처리 시 사전 생성한 `CatalogIndex` 재사용
- 카탈로그 dict 표준 형식 및 레거시 list 호환
- Excel 우편번호의 선행 0 및 텍스트 서식 유지
- issue #61 상품/옵션 오매핑 회귀 테스트

## 호환성

- 기존 발주 Excel의 컬럼 구성은 유지됩니다.
- 기존 training data의 list 형식과 새 내부 dict 형식을 모두 이력 다운로드에서 처리합니다.
- 레거시 JSONL CLI 입력도 계속 지원합니다.
- `AUTH_SECRET` 미설정 시 로그인은 기존과 동일하게 세션에만 유지됩니다.

## 제외 범위

이번 PR에는 리팩토링 문서의 P3 항목을 포함하지 않았습니다.

- 죽은 `zip_code` 정규화 분기 및 레거시 코드 정리
- `convert_chat_csv_to_jsonl.py` 개선
- logging 및 예외 처리 체계 개편
- 업로드 중복 제거의 `id()` 키 개선
- session state 키 상수화
