### PR TITLE
chore: 변환 스크립트 인자화 · 로그인 토큰 테스트 · 코드 품질 정리 (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ python3 main.py \
 | `--output` | 출력 엑셀 파일명 (기본값: `config.yaml`의 `file_name`) |
 | `--config` | 설정 파일 경로 (기본값: `config.yaml`) |
 
+### 학습용 JSONL 변환 스크립트
+
+카카오톡 CSV 대화를 학습용 JSONL로 변환하는 보조 스크립트입니다(앱 런타임과 분리).
+
+```bash
+python convert_chat_csv_to_jsonl.py \
+  --input-dir ./chat_csv \
+  --output-dir ./chat_data \
+  --prefix "이지픽_"
+```
+
+| 옵션 | 설명 |
+|---|---|
+| `--input-dir` | CSV 파일이 있는 폴더 (필수) |
+| `--output-dir` | JSONL 출력 폴더 (없으면 생성, 필수) |
+| `--prefix` | 파일명 접두사 및 glob 패턴 구성 (기본값: `이지픽_`) |
+| `--time-after` | 이 시각 이후 메시지만 포함 (선택, 예: `'2026-07-01 00:00'`) |
+
 ---
 
 ## 설정

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from database import (
     get_connection,
     get_monthly_api_call_count,
 )
+from session_keys import API_KEY, LOGGED_IN_USER, MONTHLY_EXTRACT_LIMIT
 from settings import get_env, load_prompt
 from ui import tab_catalog, tab_history, tab_order, tab_search, tab_zipcode
 from ui.common import AppContext
@@ -78,9 +79,9 @@ def _restore_login_from_cookie(cookie_manager, db_conn) -> None:
     account = get_account_by_user_id(db_conn, user_id)
     if not account:
         return
-    st.session_state["api_key"] = account["gemini_api_key"]
-    st.session_state["monthly_extract_limit"] = account["monthly_extract_limit"]
-    st.session_state["logged_in_user"] = user_id
+    st.session_state[API_KEY] = account["gemini_api_key"]
+    st.session_state[MONTHLY_EXTRACT_LIMIT] = account["monthly_extract_limit"]
+    st.session_state[LOGGED_IN_USER] = user_id
 
 
 def render_login(db_conn, cookie_manager) -> None:
@@ -110,9 +111,9 @@ def render_login(db_conn, cookie_manager) -> None:
         if not account:
             st.error("이메일/비밀번호가 올바르지 않거나 비활성화된 계정입니다.")
             return
-        st.session_state["api_key"] = account["gemini_api_key"]
-        st.session_state["monthly_extract_limit"] = account["monthly_extract_limit"]
-        st.session_state["logged_in_user"] = email
+        st.session_state[API_KEY] = account["gemini_api_key"]
+        st.session_state[MONTHLY_EXTRACT_LIMIT] = account["monthly_extract_limit"]
+        st.session_state[LOGGED_IN_USER] = email
         _persist_login_cookie(cookie_manager, email)
         st.rerun()
 
@@ -121,8 +122,8 @@ def render_sidebar(ctx: AppContext, cookie_manager) -> None:
     with st.sidebar:
         st.write(f"👤 **{ctx.user_id}**님 환영합니다.")
         if st.button("LogOut"):
-            st.session_state["logged_in_user"] = None
-            st.session_state["api_key"] = None
+            st.session_state[LOGGED_IN_USER] = None
+            st.session_state[API_KEY] = None
             _clear_login_cookie(cookie_manager)
             st.rerun()
         st.divider()
@@ -133,7 +134,7 @@ def render_sidebar(ctx: AppContext, cookie_manager) -> None:
             st.error("❌ API Key 연동 실패")
 
         used = monthly_api_usage(ctx.user_id) if ctx.db_conn else 0
-        limit = st.session_state.get("monthly_extract_limit")
+        limit = st.session_state.get(MONTHLY_EXTRACT_LIMIT)
         st.info(
             f"이번 달 사용량: {used} / "
             f"{'무제한' if limit is None else limit}"
@@ -148,14 +149,14 @@ def main() -> None:
     )
     cookie_manager = stx.CookieManager()
     db_conn = get_db()
-    st.session_state.setdefault("logged_in_user", None)
-    st.session_state.setdefault("api_key", None)
-    st.session_state.setdefault("monthly_extract_limit", None)
+    st.session_state.setdefault(LOGGED_IN_USER, None)
+    st.session_state.setdefault(API_KEY, None)
+    st.session_state.setdefault(MONTHLY_EXTRACT_LIMIT, None)
 
-    if not st.session_state["logged_in_user"]:
+    if not st.session_state[LOGGED_IN_USER]:
         _restore_login_from_cookie(cookie_manager, db_conn)
 
-    if not st.session_state["logged_in_user"]:
+    if not st.session_state[LOGGED_IN_USER]:
         render_login(db_conn, cookie_manager)
         st.stop()
 
@@ -163,8 +164,8 @@ def main() -> None:
     ctx = AppContext(
         db_conn=db_conn,
         config=config,
-        api_key=st.session_state.get("api_key") or "",
-        user_id=st.session_state["logged_in_user"],
+        api_key=st.session_state.get(API_KEY) or "",
+        user_id=st.session_state[LOGGED_IN_USER],
         juso_api_key=get_env("JUSO_API_KEY"),
         order_extraction_prompt=cached_prompt(config["prompts"]["order_extraction"]),
         address_to_search_prompt=cached_prompt(config["prompts"]["address_to_search"]),

--- a/convert_chat_csv_to_jsonl.py
+++ b/convert_chat_csv_to_jsonl.py
@@ -1,75 +1,112 @@
-from tqdm import tqdm
-import pandas as pd
-import re
-import os
+import argparse
 import glob
+import os
+import re
+
+import pandas as pd
+from tqdm import tqdm
 
 
-def normalize_multispaces(text: str) -> str:
-    return re.sub(r"\s+", " ", text).strip()
+DEFAULT_PREFIX = "이지픽_"
 
-
-PREFIX = "이지픽_"
-
-
-def extract_nickname(filepath: str, prefix=PREFIX) -> str:
-    filename = os.path.basename(filepath)
-    name = filename.removeprefix(prefix).removesuffix(".csv")
-    return name
-
-
-def convert_df_to_jsonl(
-    df: pd.DataFrame, time_after: str = None, exclude_messages: list = list()
-):
-    messages = list()
-
-    if time_after:
-        df["DATE"] = pd.to_datetime(df["DATE"])
-        time_after_dt = pd.to_datetime(time_after)
-        df = df[df["DATE"] >= time_after_dt]
-
-    for i, data in df.iterrows():
-        user = data["USER"]
-        message = data["MESSAGE"]
-        date = data["DATE"]
-        if any(message.startswith(msg) for msg in exclude_messages):
-            continue
-        messages.append({"user": user, "message": message, "date": date})
-    return messages
-
-
-def export_jsonl(data: list, out_f: str):
-    with open(out_f, "w", encoding="utf-8") as f:
-        for line in tqdm(data, desc=f"writing", mininterval=10):
-            f.write(f"{line}\n")
-    print(f"{len(data):,} lines exported to file: {out_f}")
-
-
-exclude_messages = [
+# 채널 공지/시스템 메시지 등 학습에서 제외할 문구
+EXCLUDE_MESSAGES = [
     "'이지픽' 채널을 추가해 주셔서 감사합니다.",
     "임실장이 알려주는 명품코디 꿀 TIP!",
     "알림톡/친구톡 메시지는 관리자센터에서 확인할 수 없습니다.",
 ]
 
 
-def main():
-    folder = "/home/jonas/workspace/git/test"
-    fnames = glob.glob(os.path.join(folder, "이지픽_*.csv"))
+def normalize_multispaces(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def extract_nickname(filepath: str, prefix: str = DEFAULT_PREFIX) -> str:
+    filename = os.path.basename(filepath)
+    return filename.removeprefix(prefix).removesuffix(".csv")
+
+
+def convert_df_to_jsonl(
+    df: pd.DataFrame, time_after: str = None, exclude_messages: list = None
+):
+    exclude_messages = exclude_messages or []
+    messages = []
+
+    if time_after:
+        df["DATE"] = pd.to_datetime(df["DATE"])
+        time_after_dt = pd.to_datetime(time_after)
+        df = df[df["DATE"] >= time_after_dt]
+
+    for _, data in df.iterrows():
+        message = data["MESSAGE"]
+        if any(message.startswith(msg) for msg in exclude_messages):
+            continue
+        messages.append(
+            {"user": data["USER"], "message": message, "date": data["DATE"]}
+        )
+    return messages
+
+
+def export_jsonl(data: list, out_f: str):
+    with open(out_f, "w", encoding="utf-8") as f:
+        for line in tqdm(data, desc="writing", mininterval=10):
+            f.write(f"{line}\n")
+    print(f"{len(data):,} lines exported to file: {out_f}")
+
+
+def convert_folder(
+    input_dir: str,
+    output_dir: str,
+    prefix: str = DEFAULT_PREFIX,
+    time_after: str = None,
+) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    fnames = glob.glob(os.path.join(input_dir, f"{prefix}*.csv"))
+    if not fnames:
+        print(f"[WARN] {input_dir} 에서 '{prefix}*.csv' 파일을 찾지 못했습니다.")
+        return
     for fname in fnames:
-        order_name = extract_nickname(fname)
+        order_name = extract_nickname(fname, prefix=prefix)
         df = pd.read_csv(fname, encoding="utf-8-sig", encoding_errors="replace")
-        start_date, end_date = df.iloc[0]["DATE"], df.iloc[-1]["DATE"]
-        chats = convert_df_to_jsonl(df, exclude_messages=exclude_messages)
+        end_date = df.iloc[-1]["DATE"]
+        chats = convert_df_to_jsonl(
+            df, time_after=time_after, exclude_messages=EXCLUDE_MESSAGES
+        )
         for chat_data in chats:
             chat_data["message"] = normalize_multispaces(chat_data["message"])
-        safe_end_date = end_date.replace(" ", "-").replace(":", "-")
+        safe_end_date = str(end_date).replace(" ", "-").replace(":", "-")
         export_jsonl(
-            chats,
-            os.path.join(
-                "/home/jonas/workspace/git/test/chat_data",
-                f"{order_name}_{safe_end_date}.jsonl",
-            ),
+            chats, os.path.join(output_dir, f"{order_name}_{safe_end_date}.jsonl")
         )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="카카오톡 CSV 대화를 학습용 JSONL로 변환합니다."
+    )
+    parser.add_argument("--input-dir", required=True, help="CSV 파일이 있는 폴더")
+    parser.add_argument("--output-dir", required=True, help="JSONL 출력 폴더")
+    parser.add_argument(
+        "--prefix",
+        default=DEFAULT_PREFIX,
+        help=f"파일명 접두사 및 glob 패턴 구성에 사용 (기본값: {DEFAULT_PREFIX})",
+    )
+    parser.add_argument(
+        "--time-after",
+        default=None,
+        help="이 시각 이후의 메시지만 포함 (예: '2026-07-01 00:00')",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    convert_folder(
+        input_dir=args.input_dir,
+        output_dir=args.output_dir,
+        prefix=args.prefix,
+        time_after=args.time_after,
+    )
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -111,8 +111,6 @@ def main():
     df = pd.DataFrame(all_extracted_orders, dtype=object)
     if "phone_number" in df:
         df["phone_number"] = df["phone_number"].apply(format_phone_number)
-    if "zip_code" in df.columns:
-        df["zip_code"] = df["zip_code"].apply(normalize_zip_code)
 
     juso_api_key = get_env("JUSO_API_KEY")
     if juso_api_key and "search_address" in df:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pydantic==2.13.4
 openpyxl==3.1.5
 pyyaml==6.0.3
 supabase==2.31.0
+tqdm==4.67.1
 
 # 테스트
 pytest==8.3.5

--- a/services.py
+++ b/services.py
@@ -2,6 +2,7 @@ import re
 import ast
 import json
 import io
+import logging
 import unicodedata
 import requests
 from dataclasses import dataclass, field
@@ -15,6 +16,8 @@ from google.genai import types
 from models import OrderExtractionResult, ResolvedProductItem
 from resolver import CatalogIndex, resolve_catalog_item
 
+
+logger = logging.getLogger(__name__)
 
 Catalog = dict[str, list[str]]
 
@@ -160,7 +163,7 @@ def lookup_zip_code(address: str | None, juso_api_key: str) -> str | None:
         if juso_list:
             return juso_list[0].get("zipNo")
     except Exception:
-        pass
+        logger.warning("우편번호 조회 실패 (address=%r)", address, exc_info=True)
     return None
 
 
@@ -402,7 +405,7 @@ def parse_csv(
         try:
             timestamp = pd.to_datetime(df.iloc[-1]["DATE"]).to_pydatetime()
         except Exception:
-            pass
+            logger.warning("마지막 메시지 시각 파싱 실패", exc_info=True)
 
     if (time_after or time_before) and "DATE" in df.columns:
         df["DATE"] = pd.to_datetime(df["DATE"])

--- a/session_keys.py
+++ b/session_keys.py
@@ -1,0 +1,20 @@
+"""``st.session_state`` 키 상수.
+
+문자열 리터럴을 직접 쓰면 오타·불일치를 컴파일 시점에 잡을 수 없어, 세션 상태
+접근에 사용하는 키를 한곳에 모은다. (DB/응답 dict의 키와는 별개다.)
+"""
+
+# 인증 / 계정
+LOGGED_IN_USER = "logged_in_user"
+API_KEY = "api_key"
+MONTHLY_EXTRACT_LIMIT = "monthly_extract_limit"
+
+# 주문서 추출 탭
+CHAT_DISPLAY_NAMES = "chat_display_names"
+CHAT_UPLOADER_KEY = "chat_uploader_key"
+
+# 채팅 검색 탭
+SEARCH_TRIGGER = "search_trigger"
+SEARCH_RESULTS = "search_results"
+SEARCH_PAGE = "search_page"
+SEARCH_RESULTS_KEYWORD = "search_results_keyword"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,52 @@
+import time
+
+from auth import issue_token, verify_token
+
+SECRET = "test-secret-abcdef"
+
+
+def test_valid_token_roundtrips_user_id():
+    token = issue_token("user@example.com", SECRET)
+    assert verify_token(token, SECRET) == "user@example.com"
+
+
+def test_tampered_signature_is_rejected():
+    token = issue_token("user@example.com", SECRET)
+    tampered = token[:-2] + ("00" if not token.endswith("00") else "11")
+    assert verify_token(tampered, SECRET) is None
+
+
+def test_tampered_payload_is_rejected():
+    token = issue_token("user@example.com", SECRET)
+    payload, signature = token.split(".", 1)
+    forged = issue_token("admin@example.com", SECRET).split(".", 1)[0]
+    assert verify_token(f"{forged}.{signature}", SECRET) is None
+
+
+def test_different_secret_is_rejected():
+    token = issue_token("user@example.com", SECRET)
+    assert verify_token(token, "other-secret") is None
+
+
+def test_expired_token_is_rejected():
+    token = issue_token("user@example.com", SECRET, ttl_seconds=-1)
+    assert verify_token(token, SECRET) is None
+
+
+def test_unexpired_token_is_accepted():
+    token = issue_token("user@example.com", SECRET, ttl_seconds=3600)
+    assert verify_token(token, SECRET) == "user@example.com"
+    assert time.time() > 0  # sanity: 시간 기반 만료 검증이 실행됨
+
+
+def test_empty_token_or_secret_is_rejected():
+    token = issue_token("user@example.com", SECRET)
+    assert verify_token("", SECRET) is None
+    assert verify_token(token, "") is None
+    assert verify_token(None, SECRET) is None
+
+
+def test_malformed_token_is_rejected_without_raising():
+    assert verify_token("no-dot-separator", SECRET) is None
+    assert verify_token("not_base64!!.deadbeef", SECRET) is None
+    assert verify_token("...", SECRET) is None

--- a/ui/tab_order.py
+++ b/ui/tab_order.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 from pathlib import Path
 
 import pandas as pd
@@ -16,6 +17,7 @@ from database import (
 )
 from excel_utils import write_excel_with_text_zipcode
 from resolver import CatalogIndex
+from session_keys import CHAT_DISPLAY_NAMES, CHAT_UPLOADER_KEY, MONTHLY_EXTRACT_LIMIT
 from services import (
     format_phone_number,
     lookup_zip_code,
@@ -63,7 +65,7 @@ def _render_uploaders():
             '<span class="step-badge">2</span> **대화 내역 업로드**',
             unsafe_allow_html=True,
         )
-        uploader_key = st.session_state.setdefault("chat_uploader_key", 0)
+        uploader_key = st.session_state.setdefault(CHAT_UPLOADER_KEY, 0)
         files = st.file_uploader(
             "카카오톡 대화 파일들을 업로드하세요.",
             type=["csv"],
@@ -72,17 +74,27 @@ def _render_uploaders():
         )
         files, display_names = _dedupe_uploaded_files(files or [])
         if files:
-            st.session_state["chat_display_names"] = display_names
+            st.session_state[CHAT_DISPLAY_NAMES] = display_names
             with st.expander(f"📁 업로드된 파일 {len(files)}개 보기"):
                 for uploaded in files:
-                    st.write(f"• {display_names.get(id(uploaded), uploaded.name)}")
+                    st.write(f"• {display_names.get(_file_key(uploaded), uploaded.name)}")
             if st.button("❌ 업로드 파일 전체 삭제", key="clear_chat_files"):
-                st.session_state["chat_uploader_key"] += 1
+                st.session_state[CHAT_UPLOADER_KEY] += 1
                 st.rerun()
     return catalog_file, files
 
 
-def _dedupe_uploaded_files(files: list) -> tuple[list, dict[int, str]]:
+def _file_key(uploaded) -> str:
+    """업로드 파일의 안정적인 식별 키(파일명 + 내용 해시).
+
+    id()는 rerun마다 객체가 재생성되면 바뀌어 session_state에 저장한 매핑이
+    깨진다. 내용 해시 기반 키는 rerun 간에도 동일하게 유지된다.
+    """
+    digest = hashlib.sha256(uploaded.getvalue()).hexdigest()
+    return f"{uploaded.name}:{digest}"
+
+
+def _dedupe_uploaded_files(files: list) -> tuple[list, dict[str, str]]:
     groups: dict[str, list[tuple[bytes, object]]] = {}
     for uploaded in files:
         content = uploaded.getvalue()
@@ -99,7 +111,7 @@ def _dedupe_uploaded_files(files: list) -> tuple[list, dict[int, str]]:
                 path = Path(name)
                 display_name = f"{path.stem}({index}){path.suffix}"
             unique.append(uploaded)
-            display_names[id(uploaded)] = display_name
+            display_names[_file_key(uploaded)] = display_name
     return unique, display_names
 
 
@@ -132,7 +144,7 @@ def _validate_inputs(ctx, catalog_file, chat_files) -> bool:
 
 
 def _apply_monthly_limit(ctx: AppContext, files: list) -> list:
-    limit = st.session_state.get("monthly_extract_limit")
+    limit = st.session_state.get(MONTHLY_EXTRACT_LIMIT)
     if not ctx.db_conn or limit is None:
         return files
     used = get_monthly_api_call_count(ctx.db_conn, ctx.user_id)
@@ -164,10 +176,10 @@ def _run_extraction(ctx, catalog_file, files, time_after, time_before) -> None:
         sequence = 1
         progress_text = st.empty()
         progress_bar = st.progress(0)
-        display_names = st.session_state.get("chat_display_names", {})
+        display_names = st.session_state.get(CHAT_DISPLAY_NAMES, {})
 
         for position, chat_file in enumerate(files):
-            filename = display_names.get(id(chat_file), chat_file.name)
+            filename = display_names.get(_file_key(chat_file), chat_file.name)
             progress_text.write(f"💬 채팅 내역 분석 중 ({position}/{len(files)})")
             try:
                 result = process_chat_file(

--- a/ui/tab_search.py
+++ b/ui/tab_search.py
@@ -2,6 +2,12 @@ import streamlit as st
 
 from database import get_raw_files_by_job
 from services import search_keyword_in_raw_csv
+from session_keys import (
+    SEARCH_PAGE,
+    SEARCH_RESULTS,
+    SEARCH_RESULTS_KEYWORD,
+    SEARCH_TRIGGER,
+)
 from ui.common import AppContext, select_job_ui
 
 
@@ -24,13 +30,13 @@ def render(ctx: AppContext) -> None:
         "검색 키워드 (대화 내용에서 정확히 포함된 파일을 찾습니다)",
         key="search_keyword_input",
         placeholder="예: 블랙, 환불, 입금",
-        on_change=lambda: st.session_state.update({"search_trigger": True}),
+        on_change=lambda: st.session_state.update({SEARCH_TRIGGER: True}),
     )
-    triggered = st.session_state.pop("search_trigger", False)
+    triggered = st.session_state.pop(SEARCH_TRIGGER, False)
     if st.button("🔍 검색", type="primary", key="search_run_btn") or triggered:
         _search(ctx, job, keyword)
 
-    result = st.session_state.get("search_results")
+    result = st.session_state.get(SEARCH_RESULTS)
     if not result or result.get("job_id") != job["id"]:
         return
     _render_results(result)
@@ -42,7 +48,7 @@ def _search(ctx: AppContext, job: dict, keyword: str) -> None:
         return
     raw_files = get_raw_files_by_job(conn=ctx.db_conn, job_id=job["id"])
     if not raw_files:
-        st.session_state["search_results"] = None
+        st.session_state[SEARCH_RESULTS] = None
         st.info(
             "이 작업은 원본 대화가 저장되지 않았습니다. "
             "(채팅 검색 기능 적용 이전이거나 DB 미연결 상태로 추출된 작업입니다.)"
@@ -62,7 +68,7 @@ def _search(ctx: AppContext, job: dict, keyword: str) -> None:
                     "content": raw_file.get("content", ""),
                 }
             )
-    st.session_state["search_results"] = {
+    st.session_state[SEARCH_RESULTS] = {
         "keyword": keyword,
         "job_id": job["id"],
         "items": items,
@@ -82,10 +88,10 @@ def _render_results(result: dict) -> None:
 
     page_size = 20
     total_pages = max(1, (len(items) + page_size - 1) // page_size)
-    if st.session_state.get("search_results_keyword") != result["keyword"]:
-        st.session_state["search_page"] = 0
-        st.session_state["search_results_keyword"] = result["keyword"]
-    page = min(st.session_state.get("search_page", 0), total_pages - 1)
+    if st.session_state.get(SEARCH_RESULTS_KEYWORD) != result["keyword"]:
+        st.session_state[SEARCH_PAGE] = 0
+        st.session_state[SEARCH_RESULTS_KEYWORD] = result["keyword"]
+    page = min(st.session_state.get(SEARCH_PAGE, 0), total_pages - 1)
 
     header = st.columns([6, 1])
     header[0].markdown("**채팅명**")
@@ -106,10 +112,10 @@ def _render_results(result: dict) -> None:
     st.caption(f"{page + 1} / {total_pages} 페이지")
     navigation = st.columns([1, 1, 8])
     if navigation[0].button("◀ 이전", key="search_prev", disabled=page == 0):
-        st.session_state["search_page"] = page - 1
+        st.session_state[SEARCH_PAGE] = page - 1
         st.rerun()
     if navigation[1].button(
         "다음 ▶", key="search_next", disabled=page >= total_pages - 1
     ):
-        st.session_state["search_page"] = page + 1
+        st.session_state[SEARCH_PAGE] = page + 1
         st.rerun()


### PR DESCRIPTION
## 요약

#70의 세 영역(변환 스크립트 인자화 · 로그인 토큰 테스트 · 코드 품질 정리)을 하나의 PR로 처리한다. 각 항목은 서로 독립적이며 커밋 하나에 묶여 있다.

## 변경 사항

### 1. 변환 스크립트 인자화 (`convert_chat_csv_to_jsonl.py`)

- 하드코딩된 입력/출력 경로, 채널 접두사, glob 패턴을 `argparse` 인자(`--input-dir`, `--output-dir`, `--prefix`, `--time-after`)로 분리했다.
- 출력 폴더가 없으면 생성하고(`exist_ok=True`), 매칭 파일이 없을 때 경고를 출력한다.
- `tqdm`을 `requirements.txt`에 추가했다(기존에 import만 하고 미선언).
- `README.md`에 실행 예시와 옵션 표를 추가했다.

### 2. 로그인 서명 토큰 테스트 (`tests/test_auth.py`)

- #69에서 도입한 `auth.py`(HMAC 서명 토큰)의 회귀 테스트를 추가했다: 정상 토큰, 서명/페이로드 위조, 다른 secret, 만료, 빈 값, 형식 오류.

### 3. 코드 품질 정리 (P3)

- **침묵 예외 → logging** — `services.py`의 우편번호 조회·마지막 메시지 시각 파싱에서 `except Exception: pass`로 오류를 삼키던 것을 `logging.warning(..., exc_info=True)`로 대체했다.
- **업로드 dedupe `id()` 키 제거** — `ui/tab_order.py`가 display name 매핑 키로 `id(uploaded)`를 사용했는데, 이 매핑을 `session_state`에 저장한 뒤 다음 rerun에서 객체 id가 바뀌어 매핑이 깨지는 잠재 버그가 있었다. 파일명+내용 해시 기반의 안정 키(`_file_key`)로 교체했다.
- **`session_state` 키 상수화** — 문자열 리터럴로 흩어져 있던 세션 키를 `session_keys.py` 상수 모듈로 모으고 `app.py`/`ui/tab_order.py`/`ui/tab_search.py`에 적용했다. (DB/응답 dict 키는 리터럴로 유지)
- **죽은 `zip_code` 분기 제거** — `main.py`의 `if "zip_code" in df.columns` 분기는 추출 주문 dict에 `zip_code` 키가 없어 도달 불가라 제거했다.

## 테스트

- `pytest -q`: **35 passed** (기존 27 + 신규 auth 8)
- 변경 파일 전체 `py_compile` 통과
- `app`/`session_keys`/`auth`/`ui.*`/`convert_chat_csv_to_jsonl` 임포트 스모크 통과
- `python convert_chat_csv_to_jsonl.py --help` 정상 출력

## 참고

- 동작 변경 없음(순수 정리/개선). `session_state` 접근은 상수화 후에도 키 값이 동일해 기존 세션과 호환된다.
- `id()` 키 교체는 rerun 간 파일 표시명이 유지되도록 하는 버그 수정 성격도 포함한다.

Closes #70
