### PR TITLE
fix: 월 사용량 집계를 KST 기준으로 수정 (8/1 리셋 누락)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 SUPABASE_URL=
 SUPABASE_KEY=
 JUSO_API_KEY=
+# 컨테이너 로컬 타임존. 로그 시각을 한국 시각으로 맞춥니다.
+# 월 사용량 집계는 이 값과 무관하게 항상 KST 기준으로 계산합니다(settings.KST).
+TZ=Asia/Seoul
 # 로그인 쿠키 서명용 비밀키. 길고 무작위한 값으로 설정하세요.
 # 예) python -c "import secrets; print(secrets.token_urlsafe(32))"
 # 미설정 시 로그인은 세션에만 유지되어 웹소켓 재연결 시 로그인 화면으로 튕길 수 있습니다.

--- a/app.py
+++ b/app.py
@@ -10,12 +10,11 @@ from database import (
     authenticate_user,
     get_account_by_user_id,
     get_connection,
-    get_monthly_api_call_count,
 )
 from session_keys import API_KEY, LOGGED_IN_USER, MONTHLY_EXTRACT_LIMIT
-from settings import get_env, load_prompt
+from settings import current_month_key, get_env, load_prompt
 from ui import tab_catalog, tab_history, tab_order, tab_search, tab_zipcode
-from ui.common import AppContext
+from ui.common import AppContext, monthly_api_usage
 
 
 @st.cache_resource
@@ -38,12 +37,6 @@ def load_static_text(path: str) -> str:
 @st.cache_data
 def cached_prompt(path: str) -> str:
     return load_prompt(path)
-
-
-@st.cache_data(ttl=60)
-def monthly_api_usage(user_id: str) -> int:
-    connection = get_db()
-    return get_monthly_api_call_count(connection, user_id) if connection else 0
 
 
 def _persist_login_cookie(cookie_manager, user_id: str) -> None:
@@ -133,7 +126,7 @@ def render_sidebar(ctx: AppContext, cookie_manager) -> None:
         else:
             st.error("❌ API Key 연동 실패")
 
-        used = monthly_api_usage(ctx.user_id) if ctx.db_conn else 0
+        used = monthly_api_usage(ctx.db_conn, ctx.user_id, current_month_key())
         limit = st.session_state.get(MONTHLY_EXTRACT_LIMIT)
         st.info(
             f"이번 달 사용량: {used} / "

--- a/database.py
+++ b/database.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from supabase import create_client, Client
 
+from settings import kst_month_range
+
 
 def _clean(value):
     """pandas NaN을 JSON 직렬화 가능한 None으로 변환한다."""
@@ -232,14 +234,14 @@ def save_extract_call_log(
 
 
 def get_monthly_api_call_count(conn: Client, user_id: str) -> int:
-    """이번 달(1일~말일) 동안 user_id의 API 호출 횟수를 반환합니다."""
-    now = datetime.now()
-    month_start = datetime(now.year, now.month, 1).isoformat()
+    """이번 달(KST 기준 1일 00:00 ~ 말일 24:00) user_id의 API 호출 횟수를 반환합니다."""
+    month_start, next_month = kst_month_range()
     result = (
         conn.table("extract_call_logs")
         .select("id", count="exact")
         .eq("user_id", user_id)
-        .gte("called_at", month_start)
+        .gte("called_at", month_start.isoformat())
+        .lt("called_at", next_month.isoformat())
         .execute()
     )
     return result.count if result.count is not None else 0

--- a/settings.py
+++ b/settings.py
@@ -1,8 +1,42 @@
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent
+
+# 서비스 기준 타임존. 배포 서버의 로컬 타임존(Railway 기본값 UTC)과 무관하게
+# 월 사용량 집계 경계를 한국 시각으로 고정하기 위해 사용한다.
+KST = timezone(timedelta(hours=9))
+
+
+def kst_month_range(now: datetime | None = None) -> tuple[datetime, datetime]:
+    """KST 기준 이번 달의 시작 시각과 다음 달 시작 시각을 반환합니다.
+
+    배포 서버의 로컬 타임존은 UTC이므로 ``datetime.now()``를 그대로 쓰면 KST
+    1일 00:00~09:00 구간에 아직 지난달로 판정된다. 기준 시각과 경계 양쪽에
+    KST를 명시해 서버·DB 타임존 설정과 무관하게 같은 결과를 내도록 한다.
+
+    반환값은 타임존을 가진 datetime이므로 ``isoformat()``에 ``+09:00``이
+    포함되어, 비교 대상 컬럼이 어떤 타임존으로 해석되든 경계가 밀리지 않는다.
+
+    ``now``에는 타임존을 가진 datetime을 넘길 수 있습니다(테스트용).
+    """
+    current = datetime.now(KST) if now is None else now.astimezone(KST)
+    month_start = datetime(current.year, current.month, 1, tzinfo=KST)
+    next_month = datetime(
+        current.year + current.month // 12,
+        current.month % 12 + 1,
+        1,
+        tzinfo=KST,
+    )
+    return month_start, next_month
+
+
+def current_month_key(now: datetime | None = None) -> str:
+    """KST 기준 'YYYY-MM' 문자열. 월이 바뀔 때 캐시를 무효화하는 데 사용합니다."""
+    month_start, _ = kst_month_range(now)
+    return month_start.strftime("%Y-%m")
 
 
 def get_env(name: str, default: str = "") -> str:

--- a/tests/test_month_range.py
+++ b/tests/test_month_range.py
@@ -1,0 +1,83 @@
+"""월 사용량 집계 경계(KST) 회귀 테스트.
+
+배포 서버의 로컬 타임존이 UTC라서 KST 1일 00:00~09:00 구간에 지난달로 판정되던
+버그(2026-08-01 발생)를 막는다. 서버 타임존과 무관하게 항상 KST 경계를 쓰는지
+검증한다.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from settings import KST, current_month_key, kst_month_range
+
+
+UTC = timezone.utc
+
+
+def test_kst_month_start_has_kst_offset():
+    """경계 문자열에 +09:00이 붙어야 DB가 UTC로 해석해도 밀리지 않는다."""
+    month_start, next_month = kst_month_range(datetime(2026, 8, 15, tzinfo=KST))
+    assert month_start.utcoffset() == timedelta(hours=9)
+    assert month_start.isoformat() == "2026-08-01T00:00:00+09:00"
+    assert next_month.isoformat() == "2026-09-01T00:00:00+09:00"
+
+
+def test_utc_still_july_is_counted_as_august():
+    """버그 재현 시점: KST 8/1 07:28 == UTC 7/31 22:28.
+
+    수정 전 코드는 UTC 기준으로 7월이라 판정해 사용량이 리셋되지 않았다.
+    """
+    utc_now = datetime(2026, 7, 31, 22, 28, tzinfo=UTC)
+    month_start, next_month = kst_month_range(utc_now)
+    assert (month_start.year, month_start.month) == (2026, 8)
+    assert (next_month.year, next_month.month) == (2026, 9)
+    assert current_month_key(utc_now) == "2026-08"
+
+
+def test_kst_month_first_day_before_nine_am_is_new_month():
+    """KST 1일 00:00 정각도 새 달로 판정해야 한다."""
+    assert current_month_key(datetime(2026, 8, 1, 0, 0, tzinfo=KST)) == "2026-08"
+    assert current_month_key(datetime(2026, 8, 1, 8, 59, tzinfo=KST)) == "2026-08"
+
+
+def test_kst_month_last_moment_is_previous_month():
+    """KST 말일 23:59는 아직 그 달이어야 한다(경계 반대편)."""
+    assert current_month_key(datetime(2026, 7, 31, 23, 59, tzinfo=KST)) == "2026-07"
+    month_start, next_month = kst_month_range(
+        datetime(2026, 7, 31, 23, 59, tzinfo=KST)
+    )
+    assert month_start.isoformat() == "2026-07-01T00:00:00+09:00"
+    assert next_month.isoformat() == "2026-08-01T00:00:00+09:00"
+
+
+def test_december_rolls_over_to_next_year():
+    """12월의 다음 달 경계는 익년 1월이어야 한다."""
+    month_start, next_month = kst_month_range(datetime(2026, 12, 9, tzinfo=KST))
+    assert month_start.isoformat() == "2026-12-01T00:00:00+09:00"
+    assert next_month.isoformat() == "2027-01-01T00:00:00+09:00"
+
+
+def test_range_is_half_open_and_covers_whole_month():
+    """[month_start, next_month) 구간이 그 달 전체를 빠짐없이 덮어야 한다."""
+    month_start, next_month = kst_month_range(datetime(2026, 8, 20, tzinfo=KST))
+    first_call = datetime(2026, 8, 1, 0, 0, tzinfo=KST)
+    last_call = datetime(2026, 8, 31, 23, 59, 59, tzinfo=KST)
+    previous_month_call = datetime(2026, 7, 31, 23, 59, 59, tzinfo=KST)
+    next_month_call = datetime(2026, 9, 1, 0, 0, tzinfo=KST)
+
+    assert month_start <= first_call < next_month
+    assert month_start <= last_call < next_month
+    assert not month_start <= previous_month_call < next_month
+    assert not month_start <= next_month_call < next_month
+
+
+def test_result_is_independent_of_server_local_timezone():
+    """같은 시점이면 어떤 타임존 표현으로 주어져도 결과가 같아야 한다."""
+    instant_in_utc = datetime(2026, 7, 31, 22, 28, tzinfo=UTC)
+    instant_in_kst = instant_in_utc.astimezone(KST)
+    instant_in_est = instant_in_utc.astimezone(timezone(timedelta(hours=-5)))
+
+    assert (
+        kst_month_range(instant_in_utc)
+        == kst_month_range(instant_in_kst)
+        == kst_month_range(instant_in_est)
+    )

--- a/ui/common.py
+++ b/ui/common.py
@@ -2,7 +2,23 @@ from dataclasses import dataclass
 
 import streamlit as st
 
-from database import get_jobs_by_user
+from database import get_jobs_by_user, get_monthly_api_call_count
+
+
+@st.cache_data(ttl=60)
+def monthly_api_usage(_conn, user_id: str, month_key: str) -> int:
+    """이번 달 API 호출 수를 조회한다. 사이드바 표시와 한도 차단이 함께 쓴다.
+
+    ``_conn``은 해시할 수 없는 Supabase 클라이언트이므로 언더스코어 접두사로
+    캐시 키에서 제외한다. ``month_key``는 값을 쓰지 않지만 캐시 키에 포함되어,
+    월이 바뀌면 지난달 집계가 남지 않도록 한다.
+    """
+    return get_monthly_api_call_count(_conn, user_id) if _conn else 0
+
+
+def clear_monthly_api_usage_cache() -> None:
+    """API 호출을 기록한 직후 캐시를 비워 표시·차단 값이 즉시 반영되게 한다."""
+    monthly_api_usage.clear()
 
 
 @dataclass(frozen=True)

--- a/ui/tab_order.py
+++ b/ui/tab_order.py
@@ -7,7 +7,6 @@ import streamlit as st
 
 from database import (
     create_extraction_job,
-    get_monthly_api_call_count,
     save_extract_call_log,
     save_extracted_orders,
     save_raw_chat_files,
@@ -25,7 +24,12 @@ from services import (
     parse_catalog_json,
     process_chat_file,
 )
-from ui.common import AppContext
+from settings import current_month_key
+from ui.common import (
+    AppContext,
+    clear_monthly_api_usage_cache,
+    monthly_api_usage,
+)
 
 
 MAPPING_STATUS_LABELS = {
@@ -147,7 +151,7 @@ def _apply_monthly_limit(ctx: AppContext, files: list) -> list:
     limit = st.session_state.get(MONTHLY_EXTRACT_LIMIT)
     if not ctx.db_conn or limit is None:
         return files
-    used = get_monthly_api_call_count(ctx.db_conn, ctx.user_id)
+    used = monthly_api_usage(ctx.db_conn, ctx.user_id, current_month_key())
     remaining = limit - used
     if remaining <= 0:
         st.error(
@@ -208,6 +212,7 @@ def _run_extraction(ctx, catalog_file, files, time_after, time_before) -> None:
             _update_progress(progress_bar, progress_text, position, len(files))
 
         _save_batch_result(ctx, job_id, raw_files, unresolved)
+        clear_monthly_api_usage_cache()
         status.update(label="🎉 주문 데이터 추출이 완료되었습니다!", state="complete")
 
     _render_result(ctx, job_id, orders, unresolved)


### PR DESCRIPTION
## 증상

2026년 8월 1일(토)인데도 사이드바의 `이번 달 사용량`이 7월 수치 그대로 유지되었습니다.
`admin`, `uiwe2156@gmail.com` 등 **여러 계정에서 동시에** 발생했습니다.

## 원인

배포 서버(Railway)의 로컬 타임존이 UTC라서, `datetime.now()`로 계산한 월 경계가 한국 시각과 9시간 어긋났습니다.

```
KST : 2026-08-01 07:28 (토)   ← 사용자가 보는 시각
UTC : 2026-07-31 22:28 (금)   ← 서버가 보는 시각. 아직 7월
```

기존 코드:

```python
now = datetime.now()                                        # 서버 로컬(UTC)
month_start = datetime(now.year, now.month, 1).isoformat()  # "2026-07-01T00:00:00"
```

`now.month == 7`이 되어 7월 사용량이 계속 합산되었습니다.
**매월 1일 KST 00:00~09:00의 9시간 동안 반복 발생**하며, 한도가 설정된 계정은 그 구간 동안 부당하게 차단됩니다.

### `TZ=Asia/Seoul` 환경변수만으로는 해결되지 않습니다

`datetime(2026, 8, 1).isoformat()` → `"2026-08-01T00:00:00"` 에는 **오프셋이 없습니다.**
`timestamptz` 컬럼과 비교할 때 DB 서버 타임존(UTC)으로 해석되어 경계가 KST 09:00으로 밀리고,
이번에는 반대로 KST 1일 00:00~09:00 호출이 **누락**됩니다.
기준 시각과 경계 문자열 **양쪽에** KST를 명시해야 합니다.

## 변경 사항

| 파일 | 내용 |
| --- | --- |
| `settings.py` | `KST` 상수, `kst_month_range()`, `current_month_key()` 추가. 서드파티 의존이 없는 모듈에 두어 테스트가 DB 없이 실행됩니다. |
| `database.py` | `get_monthly_api_call_count()`가 KST 경계 사용. 상한(`lt`) 추가로 미래 시각 레코드의 과다 집계 방지 |
| `ui/common.py` | 사이드바 표시와 한도 차단이 공유하는 캐시 함수로 통합. 캐시 키에 월 포함 |
| `ui/tab_order.py` | 추출 완료 직후 캐시를 비워 표시·차단 값 즉시 반영 |
| `tests/test_month_range.py` | 회귀 테스트 7건 신규 |
| `.env.example` | `TZ` 항목 추가 (로그 시각용. 집계는 이 값과 무관하게 동작) |

DB 스키마는 변경하지 않습니다. `extract_call_logs.called_at`이 `timestamp with time zone`임을 확인했으며, 시점 정보는 정확히 보존되고 있었습니다. 문제는 조회 측에만 있었습니다.

## 검증

- 전체 **81개 테스트가 `TZ=UTC`와 `TZ=Asia/Seoul` 양쪽에서 통과**
- 서버 타임존 3종에서 집계 구간이 **동일**함을 확인 (이번 수정의 핵심 검증)

```
TZ=UTC                month_key=2026-08  구간=2026-08-01T00:00:00+09:00 ~ 2026-09-01T00:00:00+09:00
TZ=Asia/Seoul         month_key=2026-08  구간=2026-08-01T00:00:00+09:00 ~ 2026-09-01T00:00:00+09:00
TZ=America/New_York   month_key=2026-08  구간=2026-08-01T00:00:00+09:00 ~ 2026-09-01T00:00:00+09:00
```

버그 발생 시점(UTC 2026-07-31 22:28) 기준 수정 전/후 비교:

```
수정 전 month_start : 2026-07-01T00:00:00          ← 7월로 판정. 리셋 안 됨
수정 후 month_start : 2026-08-01T00:00:00+09:00    ← 8월로 정상 판정
```

## 머지 후 확인

Railway `Variables`에 `TZ=Asia/Seoul` 등록 후, 아래 실측값과 화면 표시값을 대조합니다.

```sql
select user_id, count(*) as august_calls
from extract_call_logs
where called_at >= '2026-08-01T00:00:00+09:00'
  and called_at <  '2026-09-01T00:00:00+09:00'
group by user_id;
```

7월에 한도를 소진해 차단됐던 계정은 정상적으로 다시 사용 가능해집니다(카운트 기준이 7월분 → 8월분으로 바뀌므로 의도된 동작입니다).

## 남긴 항목

`database.py`의 `_rows_from()`도 naive `datetime.now()`를 쓰지만, 대상 컬럼 타입을 확인하지 못해 이번 PR 범위에서 제외했습니다. 이번 증상과는 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
