### PR TITLE
feat: Gemma 4 E2B-it LoRA SFT 설정 추가 및 학습 환경 버전 고정

### DIFF
--- a/train/README.md
+++ b/train/README.md
@@ -1,6 +1,6 @@
 # Chat2Order SFT
 
-검수·비식별화된 채팅에서 주문 JSON을 추출하도록 2B~4B급 언어 모델을 LoRA SFT하는 코드입니다. 로컬에 저장된 Qwen3.5 2B·4B와 Gemma 4 E4B-it(effective 4.5B, embedding 포함 raw 8B)를 비교합니다. Qwen3.5와 Gemma 4는 멀티모달 체크포인트지만 transformers v5의 `AutoModelForCausalLM`이 텍스트 백본만 로드하므로 학습·추론은 텍스트 전용으로 동작합니다. 단일 H100에서 BF16으로 실행하도록 설정했습니다.
+검수·비식별화된 채팅에서 주문 JSON을 추출하도록 2B~4B급 언어 모델을 LoRA SFT하는 코드입니다. 로컬에 저장된 Qwen3.5 2B·4B와 Gemma 4 E4B-it(effective 4.5B, embedding 포함 raw 8B), Gemma 4 E2B-it(raw 5.15B)를 비교합니다. Qwen3.5와 Gemma 4는 멀티모달 체크포인트지만 transformers v5의 `AutoModelForCausalLM`이 텍스트 백본만 로드하므로 학습·추론은 텍스트 전용으로 동작합니다. 단일 H100에서 BF16으로 실행하도록 설정했습니다.
 
 모델은 `order_name`, `phone_number`, `address`, `items[].raw_product`, `items[].raw_option`, `items[].volume`까지만 추출합니다. 카탈로그의 최종 `product`/`option` 선택은 학습 모델에 맡기지 않고 기존 `CatalogResolver`가 처리해야 합니다.
 
@@ -9,6 +9,7 @@
 - `configs/qwen3_5_2b.yaml`: Qwen3.5-2B 효율 비교 설정
 - `configs/qwen3_5_4b.yaml`: Qwen3.5-4B 품질 기준 설정
 - `configs/gemma4_e4b.yaml`: Gemma 4 E4B 비교 설정
+- `configs/gemma4_e2b.yaml`: Gemma 4 E2B 비교 설정(E4B와 모델만 다르고 나머지 조건 동일)
 - `data.py`: 입력 포맷, 스키마 검증, assistant-only label 생성
 - `validate_dataset.py`: schema, split 누수, token 길이 사전 검사
 - `sft.py`: Transformers Trainer + PEFT LoRA 학습
@@ -17,14 +18,16 @@
 
 ## 1. 환경 준비
 
-Python 3.11+ 기준을 권장합니다. Qwen3.5와 Gemma 4는 transformers 5.14 이상이 필요합니다.
+`train/requirements.txt`는 기록된 실험이 실제로 사용한 버전으로 고정되어 있습니다. 근거는 네 SFT 실행의 `training_manifest.json`(torch 2.13.0+cu130)과 2026-07-22 평가의 `scores/manifest.json`입니다.
 
 ```bash
-python -m venv train/.venv
-source train/.venv/bin/activate
+conda create -n c2o_train python=3.13 -y
+conda activate c2o_train
 python -m pip install --upgrade pip
 python -m pip install -r train/requirements.txt
 ```
+
+`google-genai`는 `train/evaluate.py`의 Gemini backend에만 필요하지만, 이 파일만으로 학습과 평가를 모두 실행할 수 있도록 포함했습니다. 최상위 `requirements.txt`와 같은 값이므로 두 파일의 핀을 함께 갱신하세요.
 
 GPU와 BF16 지원 여부를 확인합니다.
 
@@ -124,6 +127,13 @@ Gemma 4 E4B 비교 학습은 설정만 바꿉니다.
 ```bash
 CUDA_VISIBLE_DEVICES=0 python -m train.sft \
   --config train/configs/gemma4_e4b.yaml
+```
+
+Gemma 4 E2B는 같은 계열에서 모델 크기를 줄였을 때의 효과를 보기 위한 설정입니다. 모델 경로, `hub_id`, `revision`, `experiment_name`만 다르고 데이터·LoRA·하이퍼파라미터는 E4B와 동일합니다.
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python -m train.sft \
+  --config train/configs/gemma4_e2b.yaml
 ```
 
 중단된 실행은 마지막 checkpoint부터 재개할 수 있습니다.

--- a/train/configs/gemma4_e2b.yaml
+++ b/train/configs/gemma4_e2b.yaml
@@ -1,0 +1,56 @@
+experiment_name: gemma4-e2b-lora
+wandb_project: chat2order
+
+model:
+  name_or_path: /workspace/storage/paip-kelp-dev/models/google--gemma-4-E2B-it
+  hub_id: google/gemma-4-E2B-it
+  revision: 91230f8308d9f1dc778592ea5b2da53478cf4c9c
+  dtype: bfloat16
+  attn_implementation: sdpa
+  trust_remote_code: false
+
+data:
+  train_file: working/dataset/recovery_v1/splits/train.jsonl
+  validation_file: working/dataset/recovery_v1/splits/validation.jsonl
+  cache_dir: train/cache
+  max_length: 4096
+  truncation: error
+  prompt_head_tokens: 512
+  preprocessing_num_workers: 4
+  # Gemma 4 defaults to thinking off; keep it explicit so the training prompt
+  # and inference prompt are built identically.
+  chat_template_kwargs:
+    enable_thinking: false
+
+lora:
+  r: 32
+  lora_alpha: 64
+  lora_dropout: 0.05
+  bias: none
+  use_rslora: true
+  # Restrict LoRA to the text backbone. Gemma 4 vision/audio projections use
+  # Gemma4ClippableLinear wrappers, which PEFT does not support directly.
+  target_modules: '^model\.language_model\.layers\.\d+\.(self_attn\.(q_proj|k_proj|v_proj|o_proj)|mlp\.(gate_proj|up_proj|down_proj))$'
+
+training:
+  seed: 42
+  num_train_epochs: 3
+  per_device_train_batch_size: 4
+  per_device_eval_batch_size: 4
+  gradient_accumulation_steps: 4
+  learning_rate: 0.0001
+  weight_decay: 0.01
+  warmup_ratio: 0.05
+  lr_scheduler_type: cosine
+  max_grad_norm: 1.0
+  gradient_checkpointing: true
+  tf32: true
+  optim: adamw_torch_fused
+  logging_steps: 5
+  eval_strategy: steps
+  eval_steps: 25
+  save_strategy: steps
+  save_steps: 25
+  save_total_limit: 3
+  dataloader_num_workers: 2
+  report_to: wandb

--- a/train/requirements.txt
+++ b/train/requirements.txt
@@ -1,12 +1,20 @@
-torch>=2.8.0,<3.0.0
-transformers>=5.14.0,<6.0.0
-datasets>=4.0.0,<6.0.0
-accelerate>=1.10.0,<2.0.0
-peft>=0.19.0,<1.0.0
-PyYAML>=6.0.2,<7.0.0
-safetensors>=0.5.0,<1.0.0
-sentencepiece>=0.2.0,<1.0.0
-wandb>=0.19.0,<1.0.0
+# Pinned to the versions the recorded experiments actually ran on, so a fresh
+# environment reproduces them. Source: the four SFT runs' training_manifest.json
+# (torch 2.13.0+cu130) and the 2026-07-22 evaluation's scores/manifest.json.
+torch==2.13.0
+transformers==5.14.1
+datasets==5.0.0
+accelerate==1.14.0
+peft==0.19.1
+PyYAML==6.0.3
+safetensors==0.8.0
+sentencepiece==0.2.2
+wandb==0.28.1
+# Required by train/evaluate.py's Gemini backend. Keep this in sync with the
+# repository-root requirements.txt. The 2026-07-22 evaluation ran on 1.70.0; we
+# standardised on the higher 2.11.0 after verifying that every SDK symbol
+# evaluate.py uses still exists there.
+google-genai==2.11.0
 # Optional fast kernels for the Qwen3.5 gated-DeltaNet (linear attention)
 # layers; without them transformers falls back to slower PyTorch ops.
 # causal-conv1d>=1.5.0


### PR DESCRIPTION
## 개요

Gemma 4 E2B-it LoRA SFT 설정을 추가하고, 학습 환경을 실제 실험이 사용한 버전으로 고정합니다.

기존 SFT 실험은 Gemma 계열이 E4B-it 하나뿐이라 같은 계열 안에서 모델 크기를 줄였을 때 품질이 얼마나 떨어지는지 볼 수 없었습니다. Qwen은 4B와 2B가 모두 있어 크기 효과를 볼 수 있지만 Gemma는 대조군이 없었습니다.

Closes #80

## 변경 사항

| 파일 | 내용 |
|---|---|
| `train/configs/gemma4_e2b.yaml` | 신규. E4B 설정에서 모델 경로, `hub_id`, `revision`, `experiment_name`만 변경 |
| `train/requirements.txt` | 실험 버전으로 핀 고정, `google-genai` 추가 |
| `train/README.md` | E2B 설정·명령, conda 환경 준비 절차 |

## base model 선택: E2B-it

로컬에 `google--gemma-4-E2B`(base)와 `google--gemma-4-E2B-it`가 모두 있지만 **E2B-it**를 사용합니다.

1. E4B 실험이 `-it`이므로 E2B만 base로 하면 성능 차이가 모델 크기 때문인지 base/it 차이 때문인지 분리되지 않습니다.
2. base 계열과 it 계열의 `chat_template.jinja`가 서로 다릅니다(계열 내부는 동일 해시). base를 쓰면 학습·추론 prompt 포맷 자체가 E4B 실험과 달라집니다.
3. 학습 데이터가 1,023건이고 LoRA r=32(전체의 약 0.94%)라 chat 포맷과 지시 따르기를 처음부터 학습시킬 용량이 없습니다.

### base revision 확인

로컬 `google--gemma-4-E2B-it`는 복사된 사본이라 HF 다운로드 metadata가 없어, config에 넣을 revision을 직접 대조해 확인했습니다.

| 파일 | HF `91230f83...` 대비 |
|---|---|
| `model.safetensors` | 크기 일치 (10,246,621,918 B) |
| `config.json` | git blob 해시 일치 |
| `generation_config.json` / `processor_config.json` | 일치 |
| `tokenizer_config.json` / `chat_template.jinja` | 불일치 (로컬이 과거 스냅샷) |

사내 artifactory HF proxy가 commit 목록 API를 지원하지 않아 정확히 대응하는 과거 commit은 특정할 수 없었습니다. 다만 `sft.py`가 tokenizer와 chat template을 adapter에 함께 저장하고 `predict.py`/`merge_lora.py`가 **tokenizer를 adapter 디렉터리에서** 로드하므로, manifest의 revision은 weight 복원에만 쓰입니다. weight와 `config.json`이 byte 단위로 일치하므로 `91230f83...` pin으로 재현성이 유지됩니다. 기존 E4B-it config의 `fee6332c...`도 현재 HF main과 다르며 같은 이유로 문제되지 않습니다.

## 실행 결과

이 PR의 설정으로 학습과 평가를 이미 실행했습니다. 상세 결과는 `working/train_result.md`와 `working/evaluation/20260809_e2b/report.md`에 있습니다(`working/`은 gitignore 대상).

### 학습

| | E4B-it | E2B-it |
|---|---:|---:|
| Best eval loss | 1.071e-04 (ckpt-175) | 3.235e-05 (ckpt-150) |
| Runtime | 813.7초 | 562.8초 (-30.8%) |
| 처리량 | 3.772 samples/s | 5.453 samples/s |
| Trainable params | 69,763,072 / 8.01B | 48,316,416 / 5.15B |

### 고정 test 35건 (SHA-256 `7ae3bdf5...`)

기존 네 backend의 prediction 파일을 재사용해 다섯 결과를 **한 번의 scorer 호출로** 동시에 채점했습니다. Gemini는 반복 실행 시 17.1%의 row disagreement가 있어 재실행하지 않았습니다.

| 모델 | Schema | Semantic exact | Item F1 | 이름 | 전화 | 주소 | Peak GPU |
|---|---:|---:|---:|---:|---:|---:|---:|
| Gemma 4 E4B-it | 35/35 | 35/35 (100%) | 1.000 | 100% | 100% | 100% | 15.36 GiB |
| **Gemma 4 E2B-it** | 35/35 | 35/35 (100%) | 1.000 | 100% | 100% | 100% | **9.86 GiB** |
| Qwen3.5 4B | 35/35 | 34/35 (97.1%) | 0.983 | 100% | 100% | 100% | 8.41 GiB |
| Qwen3.5 2B | 7/35 | 7/35 (20.0%) | 0.212 | 20% | 20% | 20% | 3.80 GiB |
| Gemini 3.5 Flash | 35/35 | 30/35 (85.7%) | 0.898 | 97.1% | 100% | 97.1% | — |

### 주의해서 읽어야 할 결과

E4B와 E2B의 출력이 35건 전부 **`raw_prediction` 문자열까지 byte 단위로 동일**합니다. 출력 token 수(3,046)도 같고, paired 비교는 35 ties / 0 wins입니다.

이건 "E2B가 E4B만큼 좋다"가 아니라 **이 test set이 두 모델을 구분하지 못한다**는 뜻입니다. 35건이 모두 주문 positive이고 가명화·복원 데이터라 문장 패턴이 제한적인데, 두 모델이 같은 chat template과 같은 1,023건으로 학습됐으니 greedy decoding에서 같은 궤적을 그린 것으로 보는 편이 타당합니다. 확인된 것은 "이 35건으로는 차이를 관측할 수 없다"까지입니다.

따라서 **이 PR은 운영 모델을 E2B로 바꾸자는 제안이 아닙니다.** #74에 명시된 2차 blind set(주문 없음 25~30%, 취소·변경, 복수 완료 marker 포함 최소 200건)에서 다시 비교해야 합니다. 모델을 줄였을 때 먼저 무너지는 것은 보통 쉬운 추출이 아니라 negative 판별과 취소·변경 추론이므로, 실제 차이는 2차 set에서 드러날 가능성이 높습니다.

다만 품질이 동률인 상태에서 VRAM을 35.8% 절약하므로, #76의 INT4 양자화와는 별개의 축으로 서빙 비용을 낮출 수 있는 후보입니다.

## requirements 고정

기존 범위 지정은 실제 실험과 맞지 않았습니다. `torch>=2.8.0,<3.0.0`이었지만 네 SFT 실행의 `training_manifest.json`에는 모두 **2.13.0+cu130**이 기록되어 있어, 새 환경에서 `pip install`해도 같은 버전이 나온다는 보장이 없었습니다.

```
torch==2.13.0        transformers==5.14.1   datasets==5.0.0
accelerate==1.14.0   peft==0.19.1           PyYAML==6.0.3
safetensors==0.8.0   sentencepiece==0.2.2   wandb==0.28.1
google-genai==2.11.0
```

`google-genai`는 `train/evaluate.py`의 Gemini backend가 쓰는데 이 파일에 없어서, 학습 환경만으로는 평가를 실행할 수 없었습니다. 2026-07-22 평가는 1.70.0으로 실행했지만 최상위 `requirements.txt`와 같은 상위 버전 2.11.0으로 통일했고, `evaluate.py`가 사용하는 심볼(`Client`, `HttpOptions(timeout=)`, `ThinkingLevel.MINIMAL`, `GenerateContentConfig(response_json_schema=)`, `usage_metadata`의 token count 필드, `Candidate.finish_reason`)이 2.11.0에 모두 존재하는 것을 확인했습니다. 코드 변경은 없습니다.

## 검증

- `python -m train.validate_dataset --config train/configs/gemma4_e2b.yaml` 통과 (train 1,023 / validation 37, content overlap 0, max token 2,125)
- LoRA target 정규식이 E2B text backbone에 정상 매칭 (trainable 48,316,416 / 5,152,613,920)
- 다섯 backend가 동일한 35개 `example_id` 출력 확인
- Python 3.13.14 + 고정된 requirements 환경에서 테스트 78개 통과

## W&B

- Run: https://wandb.ai/junhot08/chat2order/runs/se0oxp9b
- Artifact: `junhot08/chat2order/gemma4-e2b-lora:latest` — COMMITTED, 215.1 MiB

학습 장비에 자격증명이 없어 offline으로 실행한 뒤 업로드했습니다. 이때 **`wandb sync`만으로는 model Artifact가 올라가지 않았습니다.** sync 로그에 `uploading artifact gemma4-e2b-lora`가 찍히지만 실제로는 run metadata의 참조만 올라가고, offline run 디렉터리(184 KiB)에 adapter 파일이 staging되지 않아 project에 collection 자체가 생기지 않았습니다. run을 `resume="must"`로 열어 `log_artifact`를 다시 호출해 해결했습니다. 앞으로 offline 학습 후에는 sync 뒤 artifact 존재를 별도로 확인해야 합니다.

## 남은 작업

- 2차 blind set 구축 후 E4B와 E2B 재비교 (#74)
